### PR TITLE
Add two option excludePath, useUpperFirst

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ npm i ctix --save-dev
 npx ctix create ./tsconfig.json # execute create mode
 ```
 
+# Breaking Change
+0.4.x ctix generate default export variable, function, class process to lowercase start. But 0.5.x ctix can set excludePath. If set excludePath optoin to true, ctix follow filename first charactor.
+
+ex>
+```
+Option excludePath set true and useUpperFirst true: TribeClass -> tribeClass 
+Option excludePath set false or useUpperFirst false: TribeClass -> TribeClass
+```
+
 # Introduction
 When you develop package for another application using TypeScript, that is compiled using by webpack, babel. webpack very popular tool for bundling. At this time you need bundle entrypoint called by index.ts. 
 
@@ -91,11 +100,14 @@ Most inconvenience from import statement that solve [module resolution](https://
 | --useTimestamp | -m | false | create, single | timestamp write on ctix comment right-side, only works in useComment option set true |
 | --useComment | -c | true | create, single | ctix comment add on first line of creted export file(default index.ts) file, that remark created from ctix |
 | --quote | -q | ' | create, single | change quote character at export syntax |
+| --outputDir | -q | ' | create, single | change quote character at export syntax |
 | --useBackupFile | -b | true | create, single | created backup file if exists export file(default index.ts) file already in directory |
 | --useRootDir | -r | false | single | output file under rootDir in tsconfig.json. |
+| --excludePath | -x | false | single | Default export name create without directory(dirname). |
+| --useUpperFirst | N/A | true | create, single | If your default export variable, class, function name keep first capital character. |
 
 ## rootDir, rootDirs
-useRootDir option activate using rootDir option in tsconfig.json. This option run below flowchart.
+useRootDir option activate using rootDir option in tsconfig.json. This option run below [flowchart](https://github.com/imjuni/ctix/blob/master/UseRootDir.md).
 
 # CLI with .ctirc
 ctix cli support `.ctirc` configuration file. Available name is only `.ctirc`. `.ctirc` configuration file can applied by each target directories and script working directory. Every configuration overwrited same feature. Also cti cli arguments forced applied. And `.ctirc` file can write [json5](https://json5.org) format. json5 spec. can comment and more feature.

--- a/UseRootDir.md
+++ b/UseRootDir.md
@@ -1,0 +1,30 @@
+# useRootDir option workflow
+
+```mermaid
+graph TD
+    A01(Start)
+    C01[tsconfig.rootDir]
+    C02[tsconfig.rootDirs]    
+
+
+    A01-->A02{use<br />rootdir config?}
+    A02-->|yes|A03{use<br /> rootDir or rootDirs}
+    A03-->|use rootDir|C01
+    C01-->A04{output directory passed?}
+    A04-->|yes|A05{output directory<br /> dirname under rootDir?}
+    A04-->|no|Z01(rootDir)
+    A05-->|yes|Z02(output directory)
+    A05-->|no|Z01
+
+    A03-->|use rootDirs|C02
+    C02-->A06[Extract<br /> first directory<br /> in rootDirs]
+    A06-->A07{output directory passed?}
+    A07-->|yes|A08{output directory<br /> dirname under rootDirs?}
+    A08-->|yes|Z03(output directory)
+    A08-->|no|Z04(rootDirs)
+    A07-->|no|Z04
+
+    A02-->|no|A09{output directory passed?}
+    A09-->|yes|D01(output directory)
+    A09-->|no|B01(cli working directory)
+```

--- a/example/type01/tsconfig.json
+++ b/example/type01/tsconfig.json
@@ -1,0 +1,78 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "dom",
+      "ES2017",
+      "ES2018",
+      "ES2019",
+    ],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": false,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "*",                        /* Base directory to resolve non-absolute module names. */
+    "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./maps",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,            /* Enables experimental support for emitting type metadata for decorators. */
+    
+    "pretty": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "src/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules/**",
+    "example/**",
+    "dist/**"
+  ]
+}

--- a/example/type02/juvenile/TriteCls.ts
+++ b/example/type02/juvenile/TriteCls.ts
@@ -1,3 +1,3 @@
-export class TriteCls {
+export default class TriteCls {
   name: string = 'TriteCls';
 }

--- a/example/type02/tsconfig.json
+++ b/example/type02/tsconfig.json
@@ -1,0 +1,78 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "dom",
+      "ES2017",
+      "ES2018",
+      "ES2019",
+    ],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": false,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "*",                        /* Base directory to resolve non-absolute module names. */
+    "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./maps",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true,            /* Enables experimental support for emitting type metadata for decorators. */
+    
+    "pretty": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "src/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules/**",
+    "example/**",
+    "dist/**"
+  ]
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
   testMatch: ['**/__tests__/*.(ts|tsx)', '**/__test__/*.(ts|tsx)'],
-  testPathIgnorePatterns: ['/node_modules/', 'example'],
+  testPathIgnorePatterns: ['/node_modules/', 'example/', 'dist/'],
   setupFilesAfterEnv: ['./jest.setup.cjs'],
   testSequencer: './test.spec.cjs',
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "source-map-support": "^0.5.21",
         "tslib": "^2.3.1",
         "typescript": "^4.6.2",
+        "upper-case-first": "^2.0.2",
         "yargs": "^17.3.0"
       },
       "bin": {
@@ -51,6 +52,7 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
+        "prettier": "^2.6.0",
         "prettier-eslint": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.1.3",
@@ -6331,15 +6333,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-eslint": {
@@ -13344,9 +13349,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true
     },
     "prettier-eslint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctix",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Automatic create index.ts file",
   "main": "dist/cti.js",
   "scripts": {
@@ -61,6 +61,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
+    "prettier": "^2.6.0",
     "prettier-eslint": "^13.0.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
@@ -90,6 +91,7 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2",
+    "upper-case-first": "^2.0.2",
     "yargs": "^17.3.0"
   }
 }

--- a/src/interfaces/ICTIXOptions.ts
+++ b/src/interfaces/ICTIXOptions.ts
@@ -81,6 +81,27 @@ export interface ICTIXOptions {
    * @default false
    */
   useRootDir: boolean;
+
+  /**
+   * Default export name create without directory(dirname)
+   * option true, export { default as WriteModule } from './src/javascript/WriteModule';
+   * option false, export { default as srcJavascriptWriteModule } from './src/javascript/WriteModule';
+   *
+   * It prevent same name module in each directory But you don't have same name module, pass true.
+   *
+   * @mode create, single
+   * @default false
+   */
+  excludePath: boolean;
+
+  /**
+   * If your default export variable, class, function name keep first capital character.
+   * Option set false, TribeClass -> tribeClass. But option set true, TribeClass -> TribeClass.
+   *
+   * @mode create, single
+   * @default true
+   */
+  useUpperFirst: boolean;
 }
 
 export type TCTIXOptionWithResolvedProject = ICTIXOptions & {

--- a/src/tools/__tests__/config.test.ts
+++ b/src/tools/__tests__/config.test.ts
@@ -148,6 +148,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
         {
@@ -166,6 +168,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
         {
@@ -184,6 +188,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
         {
@@ -202,6 +208,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
         {
@@ -220,6 +228,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
         {
@@ -238,6 +248,8 @@ describe('cti-config-test', () => {
             useTimestamp: false,
             useRootDir: false,
             verbose: false,
+            excludePath: false,
+            useUpperFirst: true,
           },
         },
       ].sort((l, r) => l.dir.localeCompare(r.dir)),

--- a/src/tools/cticonfig.ts
+++ b/src/tools/cticonfig.ts
@@ -26,9 +26,18 @@ export const getExportFilename = (exportFilenameFrom?: string | undefined | null
     (filename) => (filename === '' ? 'index.ts' : filename),
   );
 
-export function defaultOption(args?: { project?: string; exportFilename?: string }): ICTIXOptions {
+export function defaultOption(args?: {
+  project?: string;
+  exportFilename?: string;
+  excludePath?: boolean;
+  useRootDir?: boolean;
+  useUpperFirst?: boolean;
+}): ICTIXOptions {
   const project = args?.project ?? path.join(process.cwd(), 'tsconfig.json');
   const exportFilename = args?.exportFilename ?? 'index.ts';
+  const excludePath = args?.excludePath ?? false;
+  const useRootDir = args?.useRootDir ?? false;
+  const useUpperFirst = args?.useUpperFirst ?? true;
 
   return {
     addNewline: true,
@@ -40,7 +49,9 @@ export function defaultOption(args?: { project?: string; exportFilename?: string
     verbose: false,
     useBackupFile: true,
     outputDir: project,
-    useRootDir: false,
+    useRootDir,
+    excludePath,
+    useUpperFirst,
     project,
   };
 }
@@ -117,6 +128,8 @@ export function getNonEmptyOption(
     exportFilename: partialOption?.exportFilename ?? fallbackOption.exportFilename,
     outputDir: partialOption?.outputDir ?? fallbackOption.outputDir,
     useRootDir: partialOption?.useRootDir ?? fallbackOption.useRootDir,
+    excludePath: partialOption?.excludePath ?? fallbackOption.excludePath,
+    useUpperFirst: partialOption?.useUpperFirst ?? fallbackOption.useUpperFirst,
   };
 }
 
@@ -208,6 +221,9 @@ export const getMergedConfig =
           option: {
             ...rootOptions,
             project: rootOptions.project,
+            excludePath: rootOptions.excludePath,
+            useRootDir: rootOptions.useRootDir,
+            useUpperFirst: rootOptions.useUpperFirst,
             exportFilename: getExportFilename(rootOptions.exportFilename),
           },
         };
@@ -249,12 +265,16 @@ export const getMergedConfig =
                     defaultOption({
                       // exportFilename, project fields use parent options
                       exportFilename: parentOptions.exportFilename,
+                      useRootDir: parentOptions.useRootDir,
                       project: parentOptions.project,
+                      useUpperFirst: rootOptions.useUpperFirst,
+                      excludePath: parentOptions.excludePath,
                     }),
                 ),
               };
 
               nonNullableOptionMap.set(newOptionObject.dir, newOptionObject);
+
               log(
                 'exportFilename-1: ',
                 parentOptions.exportFilename,


### PR DESCRIPTION
* excludePath option remove dirname in default export
* useUpperFirst option follow filename first case
    * breaking change, as-is always set lowercase first to-be follow filename default
* add flowchart: workflow for useRootDir and output directory option
* fix broken testcase
* enhance content in README.md
* enhance error process don't pass tsconfig.json
* enhance example file set