### PR TITLE
fix(write): add index when there are no files

### DIFF
--- a/example/type04/xylophone/yellow/zoo/ZooCls.ts
+++ b/example/type04/xylophone/yellow/zoo/ZooCls.ts
@@ -1,0 +1,3 @@
+export class ZooCls {
+  parrot: boolean = false;
+}

--- a/src/tools/__tests__/clean.test.ts
+++ b/src/tools/__tests__/clean.test.ts
@@ -100,7 +100,10 @@ describe('cti-clean-test', () => {
     const withoutBackup = [
       path.join(exampleType04Path, 'index.ts'),
       path.join(exampleType04Path, 'wellmade', 'index.ts'),
+      path.join(exampleType04Path, 'xylophone', 'index.ts'),
       path.join(exampleType04Path, 'wellmade', 'carpenter', 'index.ts'),
+      path.join(exampleType04Path, 'xylophone', 'yellow', 'index.ts'),
+      path.join(exampleType04Path, 'xylophone', 'yellow', 'zoo', 'index.ts'),
     ];
 
     const withBackup = [
@@ -110,6 +113,8 @@ describe('cti-clean-test', () => {
       path.join(exampleType04Path, 'wellmade', 'index.ts.bak'),
       path.join(exampleType04Path, 'wellmade', 'carpenter', 'index.ts'),
       path.join(exampleType04Path, 'wellmade', 'carpenter', 'index.ts.bak'),
+      path.join(exampleType04Path, 'xylophone', 'yellow', 'zoo', 'index.ts'),
+      path.join(exampleType04Path, 'xylophone', 'yellow', 'zoo', 'index.ts.bak'),
     ];
 
     return files.right.length < withBackup.length

--- a/src/tools/__tests__/tsfile.test.ts
+++ b/src/tools/__tests__/tsfile.test.ts
@@ -80,6 +80,7 @@ describe('cti-tsfile-test', () => {
         path.join(exampleType04Path, 'wellmade/WhisperingCls.ts'),
         path.join(exampleType04Path, 'wellmade/carpenter/DiscussionCls.ts'),
         path.join(exampleType04Path, 'wellmade/carpenter/MakeshiftCls.ts'),
+        path.join(exampleType04Path, 'xylophone/yellow/zoo/ZooCls.ts'),
       ].sort((left, right) => left.localeCompare(right)),
       defaultExportFilenames: [
         path.join(exampleType04Path, 'index.tsx'),

--- a/src/tools/__tests__/write.test.ts
+++ b/src/tools/__tests__/write.test.ts
@@ -105,16 +105,41 @@ describe('cti-write-test-set', () => {
             "export * from './SampleEnum'",
             "export { default as index } from './index.tsx'",
             "export { default as sampleEnum } from './SampleEnum'",
+            "export * from './xylophone'",
             "export * from './wellmade'",
           ],
         },
         {
           pathname: path.join(exampleType04Path, 'wellmade'),
-          content: ["export * from './WhisperingCls'", "export * from './carpenter'"],
+          content: [
+            "export * from './WhisperingCls'",
+            "export * from './carpenter'"
+          ],
         },
         {
           pathname: path.join(exampleType04Path, 'wellmade', 'carpenter'),
-          content: ["export * from './DiscussionCls'", "export * from './MakeshiftCls'"],
+          content: [
+            "export * from './DiscussionCls'",
+            "export * from './MakeshiftCls'"
+          ],
+        },
+        {
+          pathname: path.join(exampleType04Path, 'xylophone'),
+          content: [
+            "export * from './yellow'",
+          ],
+        },
+        {
+          pathname: path.join(exampleType04Path, 'xylophone', 'yellow'),
+          content: [
+            "export * from './zoo'",
+          ],
+        },
+        {
+          pathname: path.join(exampleType04Path, 'xylophone', 'yellow', 'zoo'),
+          content: [
+            "export * from './ZooCls'",
+          ],
         },
       ].sort(),
     );

--- a/src/tools/__tests__/write.test.ts
+++ b/src/tools/__tests__/write.test.ts
@@ -20,15 +20,17 @@ const exampleRootPath = path.resolve(path.join(__dirname, '..', '..', '..', 'exa
 const exampleType04Path = path.join(exampleRootPath, 'type04');
 
 describe('cti-write-test-set', () => {
+  const cliOption = {
+    ...defaultOption(),
+    project: path.join(exampleType04Path, 'tsconfig.json'),
+    resolvedProjectDirPath: path.resolve(exampleType04Path),
+    resolvedProjectFilePath: path.resolve(path.join(exampleType04Path, 'tsconfig.json')),
+  }
+
   afterEach(async (): Promise<void> => {
     await TFU.pipe(
       getCleanFilenames({
-        cliOption: {
-          ...defaultOption(),
-          project: path.join(exampleType04Path, 'tsconfig.json'),
-          resolvedProjectDirPath: path.resolve(exampleType04Path),
-          resolvedProjectFilePath: path.resolve(path.join(exampleType04Path, 'tsconfig.json')),
-        },
+        cliOption,
       }),
       TTE.chain((args) => () => clean({ filenames: args })),
     )();
@@ -49,7 +51,7 @@ describe('cti-write-test-set', () => {
         TTE.chain((args) =>
           getMergedConfig({
             projectPath: exampleType04Path,
-            cliOption: defaultOption(),
+            cliOption,
             optionObjects: args,
           }),
         ),
@@ -160,7 +162,7 @@ describe('cti-write-test-set', () => {
         TTE.chain((args) =>
           getMergedConfig({
             projectPath: exampleType04Path,
-            cliOption: defaultOption(),
+            cliOption,
             optionObjects: args,
           }),
         ),


### PR DESCRIPTION
but there are files in sub-directories with files

structures like the following

```
\a
  a.ts
\b
  \c
    \d
      d.ts
```

adds index files to all parent directories
this allows you to access a.ts and d.ts from the root