### PR TITLE
Enhance performance create, single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
-ctix - Next generation Create TypeScript Index file
-----
+## ctix - Next generation Create TypeScript Index file
+
 [![Download Status](https://img.shields.io/npm/dw/ctix.svg)](https://npmcharts.com/compare/ctix?minimal=true) [![Github Star](https://img.shields.io/github/stars/imjuni/ctix.svg?style=popout)](https://github.com/imjuni/ctix) [![Github Issues](https://img.shields.io/github/issues-raw/imjuni/ctix.svg)](https://github.com/imjuni/ctix/issues) [![NPM version](https://img.shields.io/npm/v/ctix.svg)](https://www.npmjs.com/package/ctix) [![License](https://img.shields.io/npm/l/ctix.svg)](https://github.com/imjuni/ctix/blob/master/LICENSE) [![ctix](https://circleci.com/gh/imjuni/ctix.svg?style=shield)](https://app.circleci.com/pipelines/github/imjuni/ctix?branch=master)
 
 # Installation
+
 ```bash
 npm i ctix --save-dev
 ```
 
 # Usage
+
 ```
 ctix create -p ./tsconfig.json
 ```
 
-# Breaking Change
-0.6.x and 1.x version big different. See [migration guide](https://github.com/imjuni/ctix/blob/master/docs/MigrationGuide.md). cli command, option, ignore file changed. Support TypeScript `4.7.2` and `new file extensions(.mts, .cts, etc)`.
-
 # Introduction
-When you develop package for another application using TypeScript, that is compiled using by webpack, babel. webpack very popular tool for bundling. At this time you need bundle entrypoint called by index.ts. 
 
-Manage index.ts(export file), not so convenience. If you add file or class, function you rewrite export file over and over again. `ctix` help this work. `ctix` read .npmignore, .ctiignore file after ignore there also you can use exclude configuration in tsconfig.json. See below example, 
+You have to create a list of files when bundling with webpack and rollup, or creating documents with typedoc. It's boring to re-list files every time they change files change. ctix is a simple tool that automates the creation of file lists.
+
+# Why ctix?
+
+An application project has a clear entry point, but if it is a library project, the entry point is not clear, so you have to organize it yourself. Typedoc must explicitly specify what to document, even for an application project.
+
+1. use TypeScript compiler API
+1. create index.ts file by separating default export and export
+1. support isolatedModules option
+1. various ignore options such as gitignore, npmignore, citignore
+
+# Installation
+
+```
+npm install ctix --save-dev
+```
+
+# Usage
+
+```
+ctix single -p [tsconfig.json file path]
+```
+
+# How to works?
+
+Manage index.ts(export file), not so convenience. If you add file or class, function you rewrite export file over and over again. `ctix` help this work. `ctix` read .npmignore, .ctiignore file after ignore there also you can use exclude configuration in tsconfig.json. See below example,
 
 ```
   src/
@@ -46,7 +69,7 @@ ctix create sub-command create index.ts file below.
         export * from './Button';
 ```
 
-ctix single mode generate single file. This file suitable for webpack entrypoint. 
+ctix single mode generate single file. This file suitable for webpack entrypoint.
 
 ```
   src/
@@ -61,24 +84,29 @@ ctix single mode generate single file. This file suitable for webpack entrypoint
     export * from './src/component/Button.ts'
 ```
 
-# Why ctix?
+# Pros & Cons
+
 ## Pros
+
 1. pass tsconfig.json file, another process don't care about
 1. Support default exportation
-    * my_default_index.test.ts file create `export { default as myDefaultIndexTest } from './my_default_index.test.ts'`
+   - my_default_index.test.ts file create `export { default as myDefaultIndexTest } from './my_default_index.test.ts'`
 1. Partial ignore
-    * specific export statement exclude on index.ts file.
-    * ex> { "my_lib_package.ts": ["exists", "temp"] }
+   - specific export statement exclude on index.ts file.
+   - ex> { "my_lib_package.ts": ["exists", "temp"] }
 1. Skip empty directory
 
 ## Cons
+
 1. It may be slow for some project
-    * since ctix uses TypeScript compiler API, big projects may take time to generate index files
+   - since ctix uses TypeScript compiler API, big projects may take time to generate index files
 
 # What is difference module resolution?
+
 Most inconvenience from import statement that solve [module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html). But module resolution don't helpful for entrypoint create for bundling. ctix helpful this work.
 
 # Example
+
 Example of each command.
 
 ```bash
@@ -100,26 +128,29 @@ ctix i
 ```
 
 ## Option
-| Name | Short | Default | Command | Description |
-| :--: | -- | -- | -- | -- |
-| --config | -c | | All | configuration file(.ctirc) path |
-| --project | -p | required | All | tsconfig.json path: you must pass path with filename, like this "./tsconfig.json" |
-| --exportFilename | -f | index.ts | create, single, clean | Export filename, if you not pass this field that use "index.ts" or "index.d.ts" |
-| --useSemicolon | -s | true | create, single | add semicolon on line ending at every export statement |
-| --useTimestamp | -t | false | create, single | timestamp write on ctix comment right-side, only works in useComment option set true |
-| --useComment | -m | true | create, single | ctix comment add on first line of creted export file(default index.ts) file, that remark created from ctix |
-| --quote | -q | ' | create, single | change quote character at export syntax |
-| --keepFileExt | -k | ' | create, single | keep file extension on export statement path literal |
-| --overwrite | -w | ' | create, single | overwrite each index.ts file |
-| --skipEmptyDir | -e | ' | create | empty directory skip create index.ts file |
-| --output | -o | N/A | single | output directory |
-| --useRootDir | -r | false | single | output file under rootDir in tsconfig.json. |
-| --includeBackup | N/A | false | clean | If this option set true on clean mode what will be delete backup file. |
+
+|       Name       | Short | Default  | Command               | Description                                                                                                |
+| :--------------: | ----- | -------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+|     --config     | -c    |          | All                   | configuration file(.ctirc) path                                                                            |
+|    --project     | -p    | required | All                   | tsconfig.json path: you must pass path with filename, like this "./tsconfig.json"                          |
+| --exportFilename | -f    | index.ts | create, single, clean | Export filename, if you not pass this field that use "index.ts" or "index.d.ts"                            |
+|  --useSemicolon  | -s    | true     | create, single        | add semicolon on line ending at every export statement                                                     |
+|  --useTimestamp  | -t    | false    | create, single        | timestamp write on ctix comment right-side, only works in useComment option set true                       |
+|   --useComment   | -m    | true     | create, single        | ctix comment add on first line of creted export file(default index.ts) file, that remark created from ctix |
+|     --quote      | -q    | '        | create, single        | change quote character at export syntax                                                                    |
+|  --keepFileExt   | -k    | '        | create, single        | keep file extension on export statement path literal                                                       |
+|   --overwrite    | -w    | '        | create, single        | overwrite each index.ts file                                                                               |
+|  --skipEmptyDir  | -e    | '        | create                | empty directory skip create index.ts file                                                                  |
+|     --output     | -o    | N/A      | single                | output directory                                                                                           |
+|   --useRootDir   | -r    | false    | single                | output file under rootDir in tsconfig.json.                                                                |
+| --includeBackup  | N/A   | false    | clean                 | If this option set true on clean mode what will be delete backup file.                                     |
 
 # Ignore
+
 Ignore file 3 way that is `.gitignore`, `.npmignore`, `.ctiignore`.
 
 ## .ctiignore
+
 .ctiignore file is json with comments. See below.
 
 ```jsonc
@@ -127,12 +158,14 @@ Ignore file 3 way that is `.gitignore`, `.npmignore`, `.ctiignore`.
   "juvenile/**": "*",
   "wellmade/FlakyCls.ts": "*",
   "wellmade/WhisperingCls.ts": "*",
-  "wellmade/ChildlikeCls.ts": ["transfer","stomach"]
+  "wellmade/ChildlikeCls.ts": ["transfer", "stomach"]
 }
 ```
+
 json key indicate file path. You can use glob pattern. If set `'*'` character at value that is totally ignore file or glob pattern. If set string array that is ignore type name array.
 
 ## ignore testcase
+
 testcase directory ignore using glob pattern.
 
 ```jsonc
@@ -142,16 +175,19 @@ testcase directory ignore using glob pattern.
 }
 ```
 
-ctix auto create index.ts file empty directory because that can have children directory. So, ctix need ignore directory and file both.
+The testcase file is ignored if you add to the ignore file or if there is no export syntax.
 
 ## rootDir, rootDirs
+
 useRootDir option activate using rootDir option in tsconfig.json. This option run below [flowchart](https://github.com/imjuni/ctix/blob/master/docs/UseRootDir.md).
 
 # CLI with .ctirc
+
 ctix cli support `.ctirc` configuration file. Available name is only `.ctirc`. Also cti cli arguments forced applied. And `.ctirc` file can write [json with comments](https://www.npmjs.com/package/jsonc-parser).
 
 ## .ctirc creation
-You can use cli for `.ctirc` file creation. 
+
+You can use cli for `.ctirc` file creation.
 
 ```bash
 # create current directory
@@ -161,16 +197,22 @@ You can use cli for `.ctirc` file creation.
 > cti init -p ./server/tsconfig.json
 ```
 
+# Breaking Change
+
+0.6.x and 1.x version big different. See [migration guide](https://github.com/imjuni/ctix/blob/master/docs/MigrationGuide.md). cli command, option, ignore file changed. Support TypeScript `4.7.2` and `new file extensions(.mts, .cts, etc)`.
+
 # Programming interface
+
 Each command can use that function. Each function can pass isMessageDisplay flag second parameter. isMessageDisplay pass false or undefined after not display console message and progress.
 
-| Function | Argument |  command |
-| :- | :- | :-: |
-| createWritor | TCreateOptionWithDirInfo, isMessageDisplay | create |
-| singleWritor | TSingleOptionWithDirInfo, isMessageDisplay | single |
-| removeIndexFile | TRemoveOptionWithDirInfo, isMessageDisplay | remove |
-| createInitFile | TTInitOptionWithDirInfo, isMessageDisplay | init |
+| Function        | Argument                                   | command |
+| :-------------- | :----------------------------------------- | :-----: |
+| createWritor    | TCreateOptionWithDirInfo, isMessageDisplay | create  |
+| singleWritor    | TSingleOptionWithDirInfo, isMessageDisplay | single  |
+| removeIndexFile | TRemoveOptionWithDirInfo, isMessageDisplay | remove  |
+| createInitFile  | TTInitOptionWithDirInfo, isMessageDisplay  |  init   |
 
 # Language
-* [English](https://github.com/imjuni/ctix/blob/master/README.md)
-* [Korean](https://github.com/imjuni/ctix/blob/master/README.ko.md)
+
+- [English](https://github.com/imjuni/ctix/blob/master/README.md)
+- [Korean](https://github.com/imjuni/ctix/blob/master/README.ko.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ctix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ctix",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -17,13 +17,12 @@
         "fast-glob": "^3.2.11",
         "fast-safe-stringify": "^2.1.1",
         "find-up": "^5.0.0",
-        "globby": "^11.1.0",
         "ignore": "^5.2.0",
         "json5": "^2.2.1",
         "jsonc-parser": "^3.0.0",
         "minimatch": "^5.1.0",
         "minimist": "^1.2.6",
-        "my-easy-fp": "^0.12.0",
+        "my-easy-fp": "^0.13.0",
         "my-node-fp": "^0.5.0",
         "my-only-either": "^1.1.2",
         "ora": "^5.4.1",
@@ -32,6 +31,7 @@
         "source-map-support": "^0.5.21",
         "ts-morph": "^15.0.0",
         "tslib": "^2.4.0",
+        "type-fest": "^2.17.0",
         "typescript": "^4.7.2",
         "upper-case-first": "^2.0.2",
         "yargs": "^17.5.1"
@@ -2128,6 +2128,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2202,6 +2214,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2894,6 +2907,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -4131,6 +4145,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -6183,9 +6198,9 @@
       "dev": true
     },
     "node_modules/my-easy-fp": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/my-easy-fp/-/my-easy-fp-0.12.0.tgz",
-      "integrity": "sha512-dUvI3tT8Zkt3FElcEznQZ0H4znP5zcDiKMguJ7PrO0+f1umdkUDsPqDS0ljFlVVx5/Kq8149ZhcNOXeQUrFdVQ=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/my-easy-fp/-/my-easy-fp-0.13.0.tgz",
+      "integrity": "sha512-DPA3TwRWGsPk6LJOpyrSzQW9H0g7r0PnOKiBIQA54GkiLoxLy44tG/S0eFtJKgQwYenCmRtJZslKnMGC3KoGaw=="
     },
     "node_modules/my-node-fp": {
       "version": "0.5.0",
@@ -6534,6 +6549,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7056,6 +7072,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7844,12 +7861,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
+      "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9946,6 +9962,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
       }
     },
     "ansi-regex": {
@@ -10003,7 +10027,8 @@
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array.prototype.flat": {
       "version": "1.2.5",
@@ -10518,6 +10543,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
@@ -11475,6 +11501,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -12992,9 +13019,9 @@
       "dev": true
     },
     "my-easy-fp": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/my-easy-fp/-/my-easy-fp-0.12.0.tgz",
-      "integrity": "sha512-dUvI3tT8Zkt3FElcEznQZ0H4znP5zcDiKMguJ7PrO0+f1umdkUDsPqDS0ljFlVVx5/Kq8149ZhcNOXeQUrFdVQ=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/my-easy-fp/-/my-easy-fp-0.13.0.tgz",
+      "integrity": "sha512-DPA3TwRWGsPk6LJOpyrSzQW9H0g7r0PnOKiBIQA54GkiLoxLy44tG/S0eFtJKgQwYenCmRtJZslKnMGC3KoGaw=="
     },
     "my-node-fp": {
       "version": "0.5.0",
@@ -13266,7 +13293,8 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -13638,7 +13666,8 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "snake-case": {
       "version": "3.0.4",
@@ -14217,10 +14246,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.17.0.tgz",
+      "integrity": "sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA=="
     },
     "typescript": {
       "version": "4.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Automatic create index.ts file",
   "scripts": {
     "test": "cross-env NODE_ENV=develop DEBUG=ctix:* jest --runInBand",
@@ -91,13 +91,12 @@
     "fast-glob": "^3.2.11",
     "fast-safe-stringify": "^2.1.1",
     "find-up": "^5.0.0",
-    "globby": "^11.1.0",
     "ignore": "^5.2.0",
     "json5": "^2.2.1",
     "jsonc-parser": "^3.0.0",
     "minimatch": "^5.1.0",
     "minimist": "^1.2.6",
-    "my-easy-fp": "^0.12.0",
+    "my-easy-fp": "^0.13.0",
     "my-node-fp": "^0.5.0",
     "my-only-either": "^1.1.2",
     "ora": "^5.4.1",
@@ -106,6 +105,7 @@
     "source-map-support": "^0.5.21",
     "ts-morph": "^15.0.0",
     "tslib": "^2.4.0",
+    "type-fest": "^2.17.0",
     "typescript": "^4.7.2",
     "upper-case-first": "^2.0.2",
     "yargs": "^17.5.1"

--- a/src/ctix.ts
+++ b/src/ctix.ts
@@ -14,6 +14,7 @@ import {
 import getEmptyDescendantTree from '@ignores/getEmptyDescendantTree';
 import getIgnoreConfigContents from '@ignores/getIgnoreConfigContents';
 import getIgnoreConfigFiles from '@ignores/getIgnoreConfigFiles';
+import { bootstrap as gitignoreBootstrap } from '@ignores/gitignore';
 import createIndexInfos from '@modules/createIndexInfos';
 import getRemoveFiles from '@modules/getRemoveFiles';
 import singleIndexInfos from '@modules/singleIndexInfos';
@@ -38,6 +39,8 @@ export async function createWritor(option: TCreateOptionWithDirInfo, isMessageDi
 
     const projectDirPath = await getDirname(option.resolvedProjectFilePath);
     const project = getTypeScriptProject(option.resolvedProjectFilePath);
+
+    await gitignoreBootstrap(replaceSepToPosix(path.join(projectDirPath, '.gitignore')));
 
     spinner.update('project loading complete');
 
@@ -107,6 +110,8 @@ export async function singleWritor(option: TSingleOptionWithDirInfo, isMessageDi
     const projectDirPath = await getDirname(option.resolvedProjectFilePath);
     const project = getTypeScriptProject(option.resolvedProjectFilePath);
 
+    await gitignoreBootstrap(replaceSepToPosix(path.join(projectDirPath, '.gitignore')));
+
     spinner.update('project loading complete');
 
     const ignoreFiles = await getIgnoreConfigFiles(projectDirPath);
@@ -155,9 +160,14 @@ export async function removeIndexFile(
     reasoner.enable(isMessageDisplay ?? false);
 
     spinner.start("ctix start 'remove' mode");
-    reasoner.sleep(1000);
+    reasoner.sleep(500);
 
     const project = getTypeScriptProject(option.resolvedProjectFilePath);
+
+    await gitignoreBootstrap(
+      replaceSepToPosix(path.join(option.resolvedProjectDirPath, '.gitignore')),
+    );
+
     const filePaths = await getRemoveFiles(project, option);
 
     spinner.update(`remove each ${option.exportFilename} file`);

--- a/src/ignores/__tests__/drive.test.ts
+++ b/src/ignores/__tests__/drive.test.ts
@@ -1,0 +1,33 @@
+import { getRefineIgnorePath } from '@ignores/gitignore';
+
+test('drive.char.test', () => {
+  const testInputs = [
+    // Uppercase of drive character
+    'F:/project/node/github/erdia/src/cli/initSample.ts',
+    'F:/project/node/github/erdia/src/cli',
+    'f:/project/node/github/erdia/src/cli/initSample.ts',
+    'f:/project/node/github/erdia/src/cli',
+
+    // Lowercase of drive character
+    'f:/project/node/github/erdia/src/cli/initSample.ts',
+    'f:/project/node/github/erdia/src/cli',
+    'f:/project/node/github/erdia/src/cli/initSample.ts',
+    'f:/project/node/github/erdia/src/cli',
+
+    // Posix style Path
+    '/project/node/github/erdia/src/cli/initSample.ts',
+    '/project/node/github/erdia/src/cli',
+    '/project/node/github/erdia/src/cli/initSample.ts',
+    '/project/node/github/erdia/src/cli',
+
+    // Posix style Path
+    '/initSample.ts',
+    'initSample.ts',
+    '/cli',
+    'cli',
+  ];
+
+  const ret = testInputs.map((inp) => getRefineIgnorePath(inp));
+
+  console.log(ret);
+});

--- a/src/ignores/__tests__/ignore.test.ts
+++ b/src/ignores/__tests__/ignore.test.ts
@@ -1,6 +1,7 @@
 import getEmptyDescendantTree from '@ignores/getEmptyDescendantTree';
 import getIgnoreConfigContents from '@ignores/getIgnoreConfigContents';
 import getIgnoreConfigFiles from '@ignores/getIgnoreConfigFiles';
+import { bootstrap as gitignoreBootstrap } from '@ignores/gitignore';
 import * as env from '@testenv/env';
 import { posixJoin } from '@tools/misc';
 import consola, { LogLevel } from 'consola';
@@ -59,64 +60,70 @@ test('getIgnoreConfigContents', async () => {
 });
 
 test('getEmptyDescendantTree-case01', async () => {
-  const ignoreFiles = await getIgnoreConfigFiles(env.exampleType02Path);
+  const projectPath = env.exampleType02Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
+
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
   const ignoreContents = await getIgnoreConfigContents({
-    cwd: env.exampleType02Path,
+    cwd: projectPath,
     ...ignoreFiles,
   });
 
   const result = await getEmptyDescendantTree({
-    cwd: env.exampleType02Path,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
   const expectation = {
-    [posixJoin(env.exampleType02Path, 'juvenile')]: '*',
-    [posixJoin(env.exampleType02Path, 'juvenile', 'spill')]: '*',
-    [posixJoin(env.exampleType02Path, 'juvenile', '__tests__')]: '*',
-    [posixJoin(env.exampleType02Path, 'wellmade', '__tests__')]: '*',
+    [posixJoin(projectPath, 'juvenile')]: '*',
+    [posixJoin(projectPath, 'juvenile', 'spill')]: '*',
+    [posixJoin(projectPath, 'juvenile', '__tests__')]: '*',
+    [posixJoin(projectPath, 'wellmade', '__tests__')]: '*',
   };
 
   expect(result).toEqual(expectation);
 });
 
 test('getEmptyDescendantTree-case02', async () => {
-  const ignoreFiles = await getIgnoreConfigFiles(env.exampleType04Path);
+  const projectPath = env.exampleType04Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
+
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
   const ignoreContents = await getIgnoreConfigContents({
-    cwd: env.exampleType04Path,
+    cwd: projectPath,
     ...ignoreFiles,
   });
 
   const result = await getEmptyDescendantTree({
-    cwd: env.exampleType04Path,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
   const expectation = {
-    [posixJoin(env.exampleType04Path, 'fast-maker')]: '*',
-    [posixJoin(env.exampleType04Path, 'fast-maker/__tests__')]: '*',
-    [posixJoin(env.exampleType04Path, 'fast-maker/carpenter')]: '*',
-    [posixJoin(env.exampleType04Path, 'juvenile')]: '*',
-    [posixJoin(env.exampleType04Path, 'juvenile', 'spill')]: '*',
+    [posixJoin(projectPath, 'juvenile')]: '*',
+    [posixJoin(projectPath, 'juvenile', 'spill')]: '*',
   };
 
   expect(result).toEqual(expectation);
 });
 
 test('getEmptyDescendantTree-case03', async () => {
-  const ignoreFiles = await getIgnoreConfigFiles(env.exampleType06Path);
+  const projectPath = env.exampleType06Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
+
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
   const ignoreContents = await getIgnoreConfigContents({
-    cwd: env.exampleType06Path,
+    cwd: projectPath,
     ...ignoreFiles,
   });
 
   const result = await getEmptyDescendantTree({
-    cwd: env.exampleType06Path,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
   const expectation = {
-    [posixJoin(env.exampleType06Path, 'fast-maker/__tests__')]: '*',
+    [posixJoin(projectPath, 'fast-maker/__tests__')]: '*',
   };
 
   expect(result).toEqual(expectation);

--- a/src/ignores/getEmptyDescendantTree.ts
+++ b/src/ignores/getEmptyDescendantTree.ts
@@ -1,3 +1,4 @@
+import gitignore from '@ignores/gitignore';
 import IGetIgnoredConfigContents from '@ignores/interfaces/IGetIgnoredConfigContents';
 import getDepth from '@tools/getDepth';
 import { fastGlobWrap, posixJoin } from '@tools/misc';
@@ -12,7 +13,11 @@ export default async function getEmptyDescendantTree({
   cwd: string;
   ignores: IGetIgnoredConfigContents;
 }) {
-  const filePaths = await fastGlobWrap(path.join(cwd, '**'), { cwd, onlyDirectories: true });
+  const filePaths = await fastGlobWrap(path.join(cwd, '**'), {
+    ignore: [...gitignore.globPatterns],
+    cwd,
+    onlyDirectories: true,
+  });
 
   const emptyTerminalDirectories = (
     await Promise.all(

--- a/src/ignores/gitignore.ts
+++ b/src/ignores/gitignore.ts
@@ -1,0 +1,68 @@
+import consola from 'consola';
+import fs from 'fs';
+import ignore, { Ignore } from 'ignore';
+import { isError } from 'my-easy-fp';
+import { existsSync } from 'my-node-fp';
+import os from 'os';
+import git, { parse as parseGitignore } from 'parse-gitignore';
+import path from 'path';
+import { ReadonlyDeep } from 'type-fest';
+
+const defaultIgnore = ['**/node_modules', '**/flow-typed', '**/coverage', '**/.git'];
+
+const internalGitIgnore: { git: git.State; ig: Ignore; globPatterns: string[]; default: string[] } =
+  { default: defaultIgnore } as any;
+
+const gitignore: ReadonlyDeep<{
+  git: git.State;
+  ig: Ignore;
+  globPatterns: string[];
+  default: string[];
+}> = internalGitIgnore;
+
+export async function bootstrap(filePath: string) {
+  if (existsSync(filePath)) {
+    const fileBuf = await fs.promises.readFile(filePath);
+    const parsedIngnore = parseGitignore(fileBuf.toString());
+
+    internalGitIgnore.git = parsedIngnore;
+    internalGitIgnore.globPatterns = internalGitIgnore.git.patterns
+      .map((pattern) => [
+        path.posix.join('**', pattern, '**', '*'),
+        path.posix.join(pattern, '**', '*'),
+      ])
+      .flat();
+    internalGitIgnore.ig = ignore().add([...defaultIgnore, ...parsedIngnore.patterns]);
+  } else {
+    internalGitIgnore.globPatterns = [];
+    internalGitIgnore.ig = ignore().add([...defaultIgnore]);
+  }
+}
+
+export function getRefineIgnorePath(filePath: string): string {
+  if (os.platform() === 'win32') {
+    const matched = /^([a-zA-Z]:)(\/|)(.+)$/.exec(filePath.trim());
+    if (matched === null || matched === undefined || matched.length < 4) {
+      return filePath.startsWith('/') ? filePath.substring(1) : filePath;
+    }
+    return matched[3];
+  }
+
+  return filePath.startsWith('/') ? filePath.substring(1) : filePath;
+}
+
+export function filter(filePaths: string[]): string[] {
+  return filePaths.filter((filePath) => {
+    try {
+      const dir = getRefineIgnorePath(filePath);
+      return !internalGitIgnore.ig.ignores(dir);
+    } catch (catched) {
+      const err = isError(catched) ?? new Error('unknown error raised from gitignore.filter');
+      consola.debug(`path: ${filePath}`);
+      consola.debug(err);
+      return false;
+    }
+  });
+}
+
+export default gitignore;

--- a/src/modules/__tests__/create.test.ts
+++ b/src/modules/__tests__/create.test.ts
@@ -3,6 +3,7 @@ import { TCreateOptionWithDirInfo } from '@configs/interfaces/IOption';
 import getEmptyDescendantTree from '@ignores/getEmptyDescendantTree';
 import getIgnoreConfigContents from '@ignores/getIgnoreConfigContents';
 import getIgnoreConfigFiles from '@ignores/getIgnoreConfigFiles';
+import { bootstrap as gitignoreBootstrap } from '@ignores/gitignore';
 import createDescendantIndex from '@modules/createDescendantIndex';
 import createIndexInfos from '@modules/createIndexInfos';
 import * as env from '@testenv/env';
@@ -40,23 +41,24 @@ test('c001-createDescendantIndex-non-skip-empty-dir', async () => {
   const expectFileName = expect
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
-  const dirPath = env.exampleType03Path;
+  const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: false,
     keepFileExt: false,
     topDirDepth: 0,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
   const ignoreContents = await getIgnoreConfigContents({
-    cwd: dirPath,
+    cwd: projectPath,
     ...ignoreFiles,
   });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
@@ -119,18 +121,20 @@ test('c002-createDescendantIndex-do-skip-empty-dir', async () => {
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
-  const dirPath = env.exampleType03Path;
+  const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
+
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: true,
     keepFileExt: false,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
-  const ignoreContents = await getIgnoreConfigContents({ cwd: dirPath, ...ignoreFiles });
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
+  const ignoreContents = await getIgnoreConfigContents({ cwd: projectPath, ...ignoreFiles });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
@@ -179,18 +183,20 @@ test('c003-createDescendantIndex-do-skip-empty-dir-case02', async () => {
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
-  const dirPath = env.exampleType03Path;
+  const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
+
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: true,
     keepFileExt: false,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
-  const ignoreContents = await getIgnoreConfigContents({ cwd: dirPath, ...ignoreFiles });
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
+  const ignoreContents = await getIgnoreConfigContents({ cwd: projectPath, ...ignoreFiles });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
@@ -239,20 +245,21 @@ test('c004-createIndexInfos-non-skip-empty-dir', async () => {
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
-  const dirPath = env.exampleType03Path;
+  const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   // option modify for expectation
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: false,
     keepFileExt: false,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
-  const ignoreContents = await getIgnoreConfigContents({ cwd: dirPath, ...ignoreFiles });
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
+  const ignoreContents = await getIgnoreConfigContents({ cwd: projectPath, ...ignoreFiles });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
@@ -287,20 +294,21 @@ test('c005-createIndexInfos-do-skip-empty-dir', async () => {
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
-  const dirPath = env.exampleType03Path;
+  const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   // option modify for expectation
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: true,
     keepFileExt: false,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
-  const ignoreContents = await getIgnoreConfigContents({ cwd: dirPath, ...ignoreFiles });
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
+  const ignoreContents = await getIgnoreConfigContents({ cwd: projectPath, ...ignoreFiles });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 
@@ -335,20 +343,21 @@ test('c006-createIndexInfos-partial-ignore', async () => {
     .getState()
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
-  const dirPath = env.exampleType04Path;
+  const projectPath = env.exampleType04Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   // option modify for expectation
   const option: TCreateOptionWithDirInfo = {
     ...env.createOptionWithDirInfo,
     skipEmptyDir: true,
     keepFileExt: false,
-    topDirs: [dirPath],
+    topDirs: [projectPath],
   };
 
-  const ignoreFiles = await getIgnoreConfigFiles(dirPath);
-  const ignoreContents = await getIgnoreConfigContents({ cwd: dirPath, ...ignoreFiles });
+  const ignoreFiles = await getIgnoreConfigFiles(projectPath);
+  const ignoreContents = await getIgnoreConfigContents({ cwd: projectPath, ...ignoreFiles });
   const ignoreDirs = await getEmptyDescendantTree({
-    cwd: dirPath,
+    cwd: projectPath,
     ignores: ignoreContents.evaluated,
   });
 

--- a/src/modules/__tests__/modules.test.ts
+++ b/src/modules/__tests__/modules.test.ts
@@ -2,6 +2,7 @@ import getExportInfos from '@compilers/getExportInfos';
 import { TCreateOptionWithDirInfo, TSingleOptionWithDirInfo } from '@configs/interfaces/IOption';
 import getIgnoreConfigContents from '@ignores/getIgnoreConfigContents';
 import getIgnoreConfigFiles from '@ignores/getIgnoreConfigFiles';
+import { bootstrap as gitignoreBootstrap } from '@ignores/gitignore';
 import getDescendantExportInfo from '@modules/getDescendantExportInfo';
 import getDirPaths from '@modules/getDirPaths';
 import getFilePathOnIndex from '@modules/getFilePathOnIndex';
@@ -43,6 +44,7 @@ test('c001-getDirPaths', async () => {
     .currentTestName.replace(/^([cC][0-9]+)(-.+)/, 'expect$2.ts');
 
   const projectPath = env.exampleType03Path;
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   const ignoreFiles = await getIgnoreConfigFiles(projectPath);
   const ignoreContents = await getIgnoreConfigContents({

--- a/src/modules/__tests__/single.test.ts
+++ b/src/modules/__tests__/single.test.ts
@@ -2,6 +2,7 @@ import getExportInfos from '@compilers/getExportInfos';
 import { TSingleOptionWithDirInfo } from '@configs/interfaces/IOption';
 import getIgnoreConfigContents from '@ignores/getIgnoreConfigContents';
 import getIgnoreConfigFiles from '@ignores/getIgnoreConfigFiles';
+import { bootstrap as gitignoreBootstrap } from '@ignores/gitignore';
 import singleIndexInfos from '@modules/singleIndexInfos';
 import * as env from '@testenv/env';
 import { getTestValue, posixJoin } from '@tools/misc';
@@ -41,6 +42,8 @@ test('c001-singleIndexInfos-type03', async () => {
 
   const projectPath = env.exampleType03Path;
   const project = share.project03;
+
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   // option modify for expectation
   const option: TSingleOptionWithDirInfo = {
@@ -86,6 +89,8 @@ test('c002-singleIndexInfos-type04', async () => {
 
   const projectPath = env.exampleType04Path;
   const project = share.project04;
+
+  await gitignoreBootstrap(posixJoin(projectPath, '.gitignore'));
 
   // option modify for expectation
   const option: TSingleOptionWithDirInfo = {

--- a/src/modules/getDescendantExportInfo.ts
+++ b/src/modules/getDescendantExportInfo.ts
@@ -1,5 +1,6 @@
 import IExportInfo from '@compilers/interfaces/IExportInfo';
 import { TCreateOrSingleOption } from '@configs/interfaces/IOption';
+import gitignore, { filter as ignoreFilter } from '@ignores/gitignore';
 import IGetIgnoredConfigContents from '@ignores/interfaces/IGetIgnoredConfigContents';
 import getRelativeDepth from '@tools/getRelativeDepth';
 import IDescendantExportInfo from '@tools/interface/IDescendantExportInfo';
@@ -24,11 +25,13 @@ export default async function getDescendantExportInfo(
     .filter(([, ignoreContent]) => ignoreContent === '*')
     .map(([ignoreFilePath]) => replaceSepToPosix(path.join(ignoreFilePath, '*')));
 
-  const globDirPaths = await fastGlob(globPattern, {
-    ignore: globIgnorePatterns,
+  const globDirPathsAsis = await fastGlob(globPattern, {
+    ignore: [...globIgnorePatterns, ...gitignore.default],
     dot: true,
     onlyDirectories: true,
   });
+
+  const globDirPaths = ignoreFilter(globDirPathsAsis);
 
   const parentExportInfo = exportInfos.filter(
     (exportInfo) => exportInfo.resolvedDirPath === filePath,

--- a/src/writes/indexFileWrite.ts
+++ b/src/writes/indexFileWrite.ts
@@ -36,13 +36,12 @@ export default async function indexFileWrite(
       const indexFilePath = path.join(indexInfo.resolvedDirPath, option.exportFilename);
       const indexFileContent = indexInfo.exportStatements.join(option.eol);
       const firstLine = getFirstLineComment(option);
+      const prettierApplied = await prettierApply(
+        option.project,
+        `${firstLine}${indexFileContent}${option.eol}`,
+      );
 
       if (isTrue(option.overwrite ?? false)) {
-        const prettierApplied = await prettierApply(
-          option.project,
-          `${firstLine}${indexFileContent}${option.eol}`,
-        );
-
         // index.ts file already exist, create backup file
         if (await exists(indexFilePath)) {
           await fs.promises.writeFile(
@@ -50,24 +49,12 @@ export default async function indexFileWrite(
             await fs.promises.readFile(indexFilePath),
           );
         }
-
-        await fs.promises.writeFile(
-          indexFilePath,
-          `${firstLine}${prettierApplied.contents}${option.eol}`,
-        );
-
-        return undefined;
       }
 
       if (isFalse(await exists(indexFilePath))) {
-        const prettierApplied = await prettierApply(
-          option.project,
-          `${firstLine}${indexFileContent}${option.eol}`,
-        );
-
         await fs.promises.writeFile(
           indexFilePath,
-          `${firstLine}${prettierApplied.contents}${option.eol}`,
+          `${`${firstLine}${prettierApplied.contents}`.trim()}${option.eol}`,
         );
 
         return undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,14 +7,13 @@
     // It is faster to skip typechecking.
     // Remove if you want ts-node to do typechecking.
     "transpileOnly": true,
-
     "files": true,
-
     "compilerOptions": {
       // compilerOptions specified here will override those declared below,
       // but *only* in ts-node.  Useful if you want ts-node and tsc to use
       // different options with a single tsconfig.json.
-    }
+    },
+    "require": ["tsconfig-paths/register"]
   },
   "compileOnSave": false,
   "buildOnSave": false,
@@ -59,5 +58,5 @@
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
     "pretty": true
   },
-  "exclude": ["example/**", "dist/**", "erdia_eg/**"]
+  "exclude": ["example/**", "dist/**", "**/erdia_eg"]
 }


### PR DESCRIPTION
  * enhance performace create, single command
    * apply default ignore content: node_modules, flow-typed, coverage, .git
  * remove globby, apply [ignore](https://github.com/kaelzhang/node-ignore) on fast-glob result
  * enhance README.md
  * bug fix: output file have twice of newline > single newline