### PR TITLE
Fix #45: Output Streams & Error Code

### DIFF
--- a/src/cli/reasoner.ts
+++ b/src/cli/reasoner.ts
@@ -29,7 +29,7 @@ export function start(reasons: IReason[]): void {
     return;
   }
 
-  console.log('');
+  console.error('');
 
   reasons.forEach((reason) => {
     const typeMessage =
@@ -47,21 +47,21 @@ export function start(reasons: IReason[]): void {
 
     const chevronRight = reason.type === 'error' ? chalk.red('>') : chalk.yellow('>');
 
-    console.log(typeMessage, filename);
+    console.error(typeMessage, filename);
 
     if (isEmpty(reason.lineAndCharacter)) {
-      console.log(`   ${chevronRight} ${chalk.gray(`${filePath}`)}`);
+      console.error(`   ${chevronRight} ${chalk.gray(`${filePath}`)}`);
     } else {
-      console.log(
+      console.error(
         `   ${chevronRight} ${chalk.gray(
           `${filePath}:${reason.lineAndCharacter.line}:${reason.lineAndCharacter.character}`,
         )}`,
       );
     }
     reason.message.split('\n').forEach((splittedMessage) => {
-      console.log(`   ${chevronRight} ${chalk.gray(splittedMessage.trim())}`);
+      console.error(`   ${chevronRight} ${chalk.gray(splittedMessage.trim())}`);
     });
 
-    console.log('');
+    console.error('');
   });
 }

--- a/src/cli/spinner.ts
+++ b/src/cli/spinner.ts
@@ -1,7 +1,7 @@
 import { isNotEmpty } from 'my-easy-fp';
 import ora from 'ora';
 
-const spinner = ora('');
+const spinner = ora({ stream: process.stdout });
 
 let isMessageDisplay = false;
 

--- a/src/ctix.ts
+++ b/src/ctix.ts
@@ -64,6 +64,10 @@ export async function createWritor(option: TCreateOptionWithDirInfo, isMessageDi
         isFalse(exportDuplicationValidateResult.filePaths.includes(exportInfo.resolvedFilePath)),
     );
 
+    if (!fileNameDuplicationValidateResult.valid || !exportDuplicationValidateResult.valid) {
+      process.exitCode = 1;
+    }
+
     spinner.update(`generate ${option.exportFilename} content`);
 
     const indexInfos = await createIndexInfos(exportInfos, ignoreContents, option);
@@ -113,6 +117,10 @@ export async function singleWritor(option: TSingleOptionWithDirInfo, isMessageDi
     const exportInfos = totalExportInfos.filter((exportInfo) =>
       isFalse(exportDuplicationValidateResult.filePaths.includes(exportInfo.resolvedFilePath)),
     );
+
+    if (!exportDuplicationValidateResult.valid) {
+      process.exitCode = 1;
+    }
 
     const indexInfos = await singleIndexInfos(exportInfos, ignoreContents, option, project);
 


### PR DESCRIPTION
- Configure `ora` to send output to `stdout`
- Write validation output to `stderr` using `console.error()`
- Set the exit code to `1` when validation fails