### PR TITLE
support SyntaxKind.Identifier

### DIFF
--- a/src/compilers/getIsIsolatedModules.ts
+++ b/src/compilers/getIsIsolatedModules.ts
@@ -77,6 +77,11 @@ export default function getIsIsolatedModules(
         return false;
       }
 
+      // Identifier
+      if (exportedDeclarationNode.getKind() === tsm.SyntaxKind.Identifier) {
+        return true;
+      }
+
       throw new Error(
         `Cannot support type: (${exportedDeclarationNode.getKind()}) ${exportedDeclarationNode.getText()}`,
       );


### PR DESCRIPTION
support export identifier

```ts
export const abc = () => {
}
abc.A = 1
```