### PR TITLE
fixup!: Fixed error with `startFrom` in create mode (#109)

### DIFF
--- a/example/type10/.ctirc
+++ b/example/type10/.ctirc
@@ -11,7 +11,7 @@
       "output": "example/type10/components",
       "overwrite": true,
       "backup": false,
-      "include": ["example/type10/components/**/*.vue"]
+      "include": ["components/**/*.vue"]
     },
     {
       "mode": "bundle",

--- a/src/configs/parseConfig.ts
+++ b/src/configs/parseConfig.ts
@@ -2,23 +2,23 @@ import { readJson5 } from '#/configs/modules/json/readJson5';
 import { readJsonc } from '#/configs/modules/json/readJsonc';
 import { readYaml } from '#/configs/modules/json/readYml';
 
-export function parseConfig(buf: Buffer | string) {
+export function parseConfig<T = unknown>(buf: Buffer | string) {
   // step 01. try jsonc
-  const jsonc = readJsonc(buf);
+  const jsonc = readJsonc<T>(buf);
 
   if (jsonc.type === 'pass') {
     return jsonc.pass;
   }
 
   // step 02. try json5
-  const json5 = readJson5(buf);
+  const json5 = readJson5<T>(buf);
 
   if (json5.type === 'pass') {
     return json5.pass;
   }
 
   // step 03. try yaml
-  const yaml = readYaml(buf);
+  const yaml = readYaml<T>(buf);
 
   if (yaml.type === 'pass') {
     return yaml.pass;

--- a/src/configs/transforms/transformCreateMode.ts
+++ b/src/configs/transforms/transformCreateMode.ts
@@ -18,6 +18,10 @@ export async function transformCreateMode(
     exclude: TCreateOptions['exclude'];
   },
 ): Promise<TCreateOptions> {
+  const startFrom =
+    argv.startFrom ?? option.startFrom ?? path.resolve(await getDirname(argv.project));
+  const resolvedStartFrom = path.isAbsolute(startFrom) ? startFrom : path.resolve(startFrom);
+
   return {
     mode: CE_CTIX_BUILD_MODE.CREATE_MODE,
     project: argv.project,
@@ -36,6 +40,6 @@ export async function transformCreateMode(
     exclude: option.exclude,
 
     skipEmptyDir: argv.skipEmptyDir ?? option.skipEmptyDir ?? true,
-    startFrom: argv.startFrom ?? option.startFrom ?? path.resolve(await getDirname(argv.project)),
+    startFrom: resolvedStartFrom,
   };
 }

--- a/src/modules/commands/bundling.ts
+++ b/src/modules/commands/bundling.ts
@@ -41,15 +41,19 @@ export async function bundling(_buildOptions: TCommandBuildOptions, bundleOption
   Spinner.it.update('include, exclude config');
 
   const output = path.resolve(path.join(bundleOption.output, bundleOption.exportFilename));
+  const filePaths = project
+    .getSourceFiles()
+    .map((sourceFile) => sourceFile.getFilePath().toString());
 
   const include = new IncludeContainer({
     config: { include: getTsIncludeFiles({ config: bundleOption, extend: extendOptions }) },
+    cwd: extendOptions.resolved.projectDirPath,
   });
 
   const inlineExcludeds = getInlineExcludedFiles({
     project,
     extendOptions,
-    filePaths: extendOptions.tsconfig.fileNames,
+    filePaths,
   });
 
   /**
@@ -61,9 +65,10 @@ export async function bundling(_buildOptions: TCommandBuildOptions, bundleOption
       exclude: [...getTsExcludeFiles({ config: bundleOption, extend: extendOptions }), ...[output]],
     },
     inlineExcludeds,
+    cwd: extendOptions.resolved.projectDirPath,
   });
 
-  const filenames = extendOptions.tsconfig.fileNames
+  const filenames = filePaths
     .filter((filename) => include.isInclude(filename))
     .filter((filename) => !exclude.isExclude(filename));
 

--- a/src/modules/commands/moduling.ts
+++ b/src/modules/commands/moduling.ts
@@ -36,6 +36,7 @@ export async function moduling(_buildOptions: TCommandBuildOptions, moduleOption
 
   const include = new IncludeContainer({
     config: { include: getTsIncludeFiles({ config: moduleOption, extend: extendOptions }) },
+    cwd: extendOptions.resolved.projectDirPath,
   });
 
   const inlineExcludeds = getInlineExcludedFiles({
@@ -53,6 +54,7 @@ export async function moduling(_buildOptions: TCommandBuildOptions, moduleOption
       exclude: [...getTsExcludeFiles({ config: moduleOption, extend: extendOptions }), ...[output]],
     },
     inlineExcludeds,
+    cwd: extendOptions.resolved.projectDirPath,
   });
 
   const filenames = include.files().filter((filename) => !exclude.isExclude(filename));

--- a/src/modules/commands/removing.ts
+++ b/src/modules/commands/removing.ts
@@ -18,6 +18,7 @@ export async function removing(
 
   const include = new IncludeContainer({
     config: { include: patterns.map((projectDir) => projectDir.pattern) },
+    cwd: process.cwd(),
   });
   const filePaths = include.files();
 

--- a/src/modules/scope/IncludeContainer.ts
+++ b/src/modules/scope/IncludeContainer.ts
@@ -9,23 +9,23 @@ export class IncludeContainer {
 
   #map: Map<string, boolean>;
 
-  constructor(args: { config: Pick<IModeGenerateOptions, 'include'>; cwd?: string }) {
-    const globs = new Glob(args.config.include, {
+  constructor(params: { config: Pick<IModeGenerateOptions, 'include'>; cwd: string }) {
+    const globs = new Glob(params.config.include, {
+      absolute: true,
       ignore: defaultExclude,
-      cwd: args.cwd ?? process.cwd(),
+      cwd: params.cwd,
     });
 
-    this.#map = new Map<string, boolean>();
-
-    for (const filePath of globs) {
-      this.#map.set(path.resolve(filePath), true);
-    }
-
+    this.#map = new Map<string, boolean>(getGlobFiles(globs).map((filePath) => [filePath, true]));
     this.#globs = [globs];
   }
 
   get globs(): Readonly<Glob<GlobOptions>[]> {
     return this.#globs;
+  }
+
+  get map(): Readonly<Map<string, boolean>> {
+    return this.#map;
   }
 
   isInclude(filePath: string): boolean {

--- a/src/modules/scope/__tests__/exclude.container.test.ts
+++ b/src/modules/scope/__tests__/exclude.container.test.ts
@@ -7,15 +7,18 @@ describe('ExcludeContainer', () => {
     const container = new ExcludeContainer({
       config: { exclude: ['src/cli/**/*.ts', 'src/compilers/**/*.ts'] },
       inlineExcludeds: [],
+      cwd: process.cwd(),
     });
 
     expect(container.globs).toBeDefined();
+    expect(container.map).toBeDefined();
   });
 
   it('isExclude - no glob files', () => {
     const container = new ExcludeContainer({
       config: { exclude: [] },
       inlineExcludeds: [],
+      cwd: process.cwd(),
     });
 
     const r01 = container.isExclude('src/files/IncludeContainer.ts');
@@ -47,6 +50,7 @@ describe('ExcludeContainer', () => {
           filePath: path.resolve('example/type03/HandsomelyCls.tsx'),
         },
       ],
+      cwd: process.cwd(),
     });
 
     const r01 = container.isExclude('src/files/IncludeContainer.ts');
@@ -75,6 +79,7 @@ describe('ExcludeContainer', () => {
         ],
       },
       inlineExcludeds: [],
+      cwd: process.cwd(),
     });
 
     const r01 = container.isExclude('src/files/IncludeContainer.ts');

--- a/src/modules/scope/__tests__/include.container.test.ts
+++ b/src/modules/scope/__tests__/include.container.test.ts
@@ -9,14 +9,17 @@ describe('IncludeContainer', () => {
   it('getter', () => {
     const container = new IncludeContainer({
       config: { include: ['src/cli/**/*.ts', 'src/compilers/**/*.ts', 'examples/**/*.ts'] },
+      cwd: process.cwd(),
     });
 
     expect(container.globs).toBeDefined();
+    expect(container.map).toBeDefined();
   });
 
   it('isInclude - no glob files', () => {
     const container = new IncludeContainer({
       config: { include: [] },
+      cwd: process.cwd(),
     });
 
     const r01 = container.isInclude('src/files/IncludeContainer.ts');
@@ -26,6 +29,7 @@ describe('IncludeContainer', () => {
   it('isInclude', () => {
     const container = new IncludeContainer({
       config: { include: ['src/cli/**/*.ts', 'src/compilers/**/*.ts', 'examples/**/*.ts'] },
+      cwd: process.cwd(),
     });
 
     const r01 = container.isInclude('src/files/IncludeContainer.ts');
@@ -51,6 +55,7 @@ describe('IncludeContainer', () => {
           'examples/**/*.ts',
         ],
       },
+      cwd: process.cwd(),
     });
 
     const r01 = container.isInclude('src/files/IncludeContainer.ts');
@@ -75,10 +80,12 @@ describe('IncludeContainer', () => {
       new Glob('example/type03/**/*.ts', {
         ignore: defaultExclude,
         cwd: process.cwd(),
+        absolute: true,
       }),
     );
     const container = new IncludeContainer({
       config: { include: ['example/type03/**/*.ts'] },
+      cwd: process.cwd(),
     });
 
     const r01 = container.files();


### PR DESCRIPTION
- When using the `skipEmptyDir` option, the parent directory must be traversed to write the `index.ts` file, if the `startFrom` option is specified as a relative path, it must be changed to an absolute path to properly traverse the parent directory
- Fixed a bug where the `include`, `exclude` logic passed `cwd` to the path where the script was executed, causing Monorepo to be unable to read the source code if the `tsconfig.json` file was passed in a different directory from where the script was executed
  - As a result of this change, `include` and `exclude` must be written relative to the path where the `tsconfig.json` file was passed