### PR TITLE
feat(config): enhance configuration file creation command

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "chalk": "^4.1.2",
     "change-case": "^4.1.2",
     "cli-progress": "^3.12.0",
+    "comment-json": "^4.2.4",
     "comment-parser": "^1.4.1",
     "consola": "^3.2.3",
     "dayjs": "^1.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
+      comment-json:
+        specifier: ^4.2.4
+        version: 4.2.4
       comment-parser:
         specifier: ^1.4.1
         version: 1.4.1
@@ -1115,6 +1118,9 @@ packages:
     resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
     engines: {node: '>= 0.4'}
 
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -1284,6 +1290,10 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
+  comment-json@4.2.4:
+    resolution: {integrity: sha512-E5AjpSW+O+N5T2GsOQMHLLsJvrYw6G/AFt9GvU6NguEAfzKShh7hRiLtVo6S9KbRpFMGqE5ojo0/hE+sdteWvQ==}
+    engines: {node: '>= 6'}
+
   comment-parser@1.4.1:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
     engines: {node: '>= 12.0.0'}
@@ -1323,6 +1333,9 @@ packages:
     resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cosmiconfig-typescript-loader@5.0.0:
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
@@ -1614,6 +1627,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -1830,6 +1848,10 @@ packages:
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-own-prop@2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.1:
@@ -2598,6 +2620,10 @@ packages:
   regexp.prototype.flags@1.5.1:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4075,6 +4101,8 @@ snapshots:
       get-intrinsic: 1.2.2
       is-string: 1.0.7
 
+  array-timsort@1.0.3: {}
+
   array-union@2.1.0: {}
 
   array.prototype.findlastindex@1.2.3:
@@ -4281,6 +4309,14 @@ snapshots:
 
   commander@9.5.0: {}
 
+  comment-json@4.2.4:
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
+
   comment-parser@1.4.1: {}
 
   common-tags@1.8.2: {}
@@ -4318,6 +4354,8 @@ snapshots:
       is-text-path: 2.0.0
       meow: 12.1.1
       split2: 4.2.0
+
+  core-util-is@1.0.3: {}
 
   cosmiconfig-typescript-loader@5.0.0(@types/node@20.9.0)(cosmiconfig@9.0.0(typescript@5.5.2))(typescript@5.5.2):
     dependencies:
@@ -4747,6 +4785,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.5.0:
     dependencies:
       estraverse: 5.3.0
@@ -4974,6 +5014,8 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-own-prop@2.0.0: {}
 
   has-property-descriptors@1.0.1:
     dependencies:
@@ -5729,6 +5771,8 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.1
       set-function-name: 2.0.1
+
+  repeat-string@1.6.1: {}
 
   require-directory@2.1.1: {}
 

--- a/src/cli/interfaces/IInitQuestionAnswer.ts
+++ b/src/cli/interfaces/IInitQuestionAnswer.ts
@@ -5,6 +5,10 @@ export interface IInitQuestionAnswer {
   tsconfig: string[];
   mode: CE_CTIX_BUILD_MODE;
   overwirte: boolean;
+  packageJson: string;
+  addEveryOptions: boolean;
+  configComment: boolean;
+  confirmBackupPackageTsconfig: boolean;
   configPosition: '.ctirc' | 'tsconfig.json' | 'package.json';
   exportFilename: string;
 }

--- a/src/cli/questions/askInitOptions.ts
+++ b/src/cli/questions/askInitOptions.ts
@@ -3,12 +3,12 @@ import { CE_CTIX_BUILD_MODE } from '#/configs/const-enum/CE_CTIX_BUILD_MODE';
 import { CE_CTIX_DEFAULT_VALUE } from '#/configs/const-enum/CE_CTIX_DEFAULT_VALUE';
 import { getTsconfigComparer } from '#/configs/modules/getTsconfigComparer';
 import { getGlobFiles } from '#/modules/file/getGlobFiles';
-import { posixJoin } from '#/modules/path/modules/posixJoin';
 import { defaultExclude } from '#/modules/scope/defaultExclude';
 import chalk from 'chalk';
 import { exists } from 'find-up';
 import { Glob } from 'glob';
 import inquirer from 'inquirer';
+import pathe from 'pathe';
 
 export async function askInitOptions(): Promise<IInitQuestionAnswer> {
   const cwd = process.cwd();
@@ -22,14 +22,20 @@ export async function askInitOptions(): Promise<IInitQuestionAnswer> {
     },
   ]);
 
-  const optionFilePath = posixJoin(cwdAnswer.cwd, CE_CTIX_DEFAULT_VALUE.CONFIG_FILENAME);
+  const optionFilePath = pathe.join(cwdAnswer.cwd, CE_CTIX_DEFAULT_VALUE.CONFIG_FILENAME);
   const optionFileExist = await exists(optionFilePath);
-  const glob = new Glob(['**/tsconfig.json', '**/tsconfig.*.json'], {
+  const tsconfigGlob = new Glob(['**/tsconfig.json', '**/tsconfig.*.json'], {
     cwd: cwdAnswer.cwd,
     ignore: defaultExclude,
   });
-  const tsconfigFiles = getGlobFiles(glob);
+  const tsconfigFiles = getGlobFiles(tsconfigGlob);
+  const packageJsonGlob = new Glob(['**/package.json'], {
+    cwd: cwdAnswer.cwd,
+    ignore: defaultExclude,
+  });
+  const packageJsonFiles = getGlobFiles(packageJsonGlob);
   const sortedTsconfigFiles = tsconfigFiles.sort(getTsconfigComparer(cwdAnswer.cwd));
+  const sortedPackageJsonFiles = packageJsonFiles.sort(getTsconfigComparer(cwdAnswer.cwd));
 
   const userSelectedAnswer = await inquirer.prompt<Omit<IInitQuestionAnswer, 'cwd' | 'overwrite'>>([
     {
@@ -47,11 +53,45 @@ export async function askInitOptions(): Promise<IInitQuestionAnswer> {
       choices: [CE_CTIX_BUILD_MODE.BUNDLE_MODE, CE_CTIX_BUILD_MODE.CREATE_MODE],
     },
     {
+      type: 'confirm',
+      name: 'addEveryOptions',
+      message: 'Do you want to include all available options in the configuration file?',
+      default: false,
+    },
+    {
       type: 'list',
       name: 'configPosition',
       message: 'Where do you want to add the configuration?',
       default: '.ctirc',
       choices: ['.ctirc', 'tsconfig.json', 'package.json'],
+    },
+    {
+      type: 'list',
+      name: 'packageJson',
+      message: 'Select your package.json files',
+      default: sortedPackageJsonFiles,
+      choices: sortedPackageJsonFiles,
+      when: (answer) => {
+        return answer.configPosition === 'package.json';
+      },
+    },
+    {
+      type: 'confirm',
+      name: 'configComment',
+      message: 'Do you want to add a comment to the configuration?',
+      default: true,
+      when: (answer) => {
+        return answer.configPosition !== 'package.json';
+      },
+    },
+    {
+      type: 'confirm',
+      name: 'confirmBackupPackageTsconfig',
+      message: (answer) => `Do you want to create a backup file from ${answer.configPosition}?`,
+      default: true,
+      when: (answer) => {
+        return answer.configPosition === 'tsconfig.json';
+      },
     },
     {
       type: 'input',
@@ -76,8 +116,12 @@ export async function askInitOptions(): Promise<IInitQuestionAnswer> {
         cwd: cwdAnswer.cwd,
         overwirte: overwriteAnswer.overwirte,
         tsconfig: [],
+        addEveryOptions: false,
+        packageJson: pathe.join(process.cwd(), CE_CTIX_DEFAULT_VALUE.PACKAGE_JSON_FILENAME),
         mode: CE_CTIX_BUILD_MODE.BUNDLE_MODE,
         configPosition: '.ctirc',
+        configComment: true,
+        confirmBackupPackageTsconfig: true,
         exportFilename: CE_CTIX_DEFAULT_VALUE.EXPORT_FILENAME,
       } satisfies IInitQuestionAnswer;
     }

--- a/src/comments/getOutputExcludedFiles.ts
+++ b/src/comments/getOutputExcludedFiles.ts
@@ -1,7 +1,7 @@
 import type { IExtendOptions } from '#/configs/interfaces/IExtendOptions';
-import { posixJoin } from '#/modules/path/modules/posixJoin';
 import { settify } from 'my-easy-fp';
 import { getDirname } from 'my-node-fp';
+import pathe from 'pathe';
 import type * as tsm from 'ts-morph';
 
 export async function getOutputExcludedFiles(params: {
@@ -22,7 +22,7 @@ export async function getOutputExcludedFiles(params: {
   );
 
   const outputFiles = settify(outputDirPaths).map((dirPath) =>
-    posixJoin(dirPath, params.exportFilename),
+    pathe.join(dirPath, params.exportFilename),
   );
 
   return outputFiles;

--- a/src/compilers/StatementTable.ts
+++ b/src/compilers/StatementTable.ts
@@ -1,7 +1,7 @@
 import type { IExportStatement } from '#/compilers/interfaces/IExportStatement';
 import type { IReason } from '#/compilers/interfaces/IReason';
-import { posixJoin } from '#/modules/path/modules/posixJoin';
 import chalk from 'chalk';
+import pathe from 'pathe';
 
 export class StatementTable {
   static key(statement: string | IExportStatement): string {
@@ -60,10 +60,10 @@ export class StatementTable {
       return false;
     }
 
-    const prevStatementKey = `${posixJoin(first.path.dirPath, first.path.filename)}::${
+    const prevStatementKey = `${pathe.join(first.path.dirPath, first.path.filename)}::${
       first.identifier.alias
     }`;
-    const nextStatementKey = `${posixJoin(statement.path.dirPath, statement.path.filename)}::${
+    const nextStatementKey = `${pathe.join(statement.path.dirPath, statement.path.filename)}::${
       statement.identifier.alias
     }`;
 
@@ -87,7 +87,7 @@ export class StatementTable {
             const reason: IReason = {
               type: 'warn',
               lineAndCharacter: { line: statement.pos.line, character: statement.pos.column },
-              filePath: posixJoin(statement.path.dirPath, statement.path.filename),
+              filePath: pathe.join(statement.path.dirPath, statement.path.filename),
               message: `detect same name of default export statement: "${chalk.yellow(
                 StatementTable.key(statement),
               )}"`,
@@ -99,7 +99,7 @@ export class StatementTable {
           const reason: IReason = {
             type: 'warn',
             lineAndCharacter: { line: statement.pos.line, character: statement.pos.column },
-            filePath: posixJoin(statement.path.dirPath, statement.path.filename),
+            filePath: pathe.join(statement.path.dirPath, statement.path.filename),
             message: `detect same name of export statement: "${chalk.yellow(
               StatementTable.key(statement),
             )}"`,

--- a/src/configs/const-enum/CE_CTIX_DEFAULT_VALUE.ts
+++ b/src/configs/const-enum/CE_CTIX_DEFAULT_VALUE.ts
@@ -2,6 +2,7 @@ export const CE_CTIX_DEFAULT_VALUE = {
   CONFIG_FILENAME: '.ctirc',
   TSCONFIG_FILENAME: 'tsconfig.json',
   EXPORT_FILENAME: 'index.ts',
+  PACKAGE_JSON_FILENAME: 'package.json',
   REMOVE_FILE_CHOICE_FUZZY: 50,
 } as const;
 

--- a/src/configs/modules/getDefaultInitAnswer.ts
+++ b/src/configs/modules/getDefaultInitAnswer.ts
@@ -5,6 +5,7 @@ import { getTsconfigComparer } from '#/configs/modules/getTsconfigComparer';
 import { getGlobFiles } from '#/modules/file/getGlobFiles';
 import { defaultExclude } from '#/modules/scope/defaultExclude';
 import { Glob } from 'glob';
+import pathe from 'pathe';
 
 export async function getDefaultInitAnswer(): Promise<IInitQuestionAnswer> {
   const cwd = process.cwd();
@@ -23,9 +24,13 @@ export async function getDefaultInitAnswer(): Promise<IInitQuestionAnswer> {
   const answer: IInitQuestionAnswer = {
     cwd,
     tsconfig: [tsconfigPath],
+    packageJson: pathe.join(process.cwd(), CE_CTIX_DEFAULT_VALUE.PACKAGE_JSON_FILENAME),
     mode: CE_CTIX_BUILD_MODE.BUNDLE_MODE,
     exportFilename: CE_CTIX_DEFAULT_VALUE.EXPORT_FILENAME,
+    addEveryOptions: false,
+    configComment: true,
     configPosition: '.ctirc',
+    confirmBackupPackageTsconfig: true,
     overwirte: true,
   };
 

--- a/src/configs/transforms/transformCreateMode.ts
+++ b/src/configs/transforms/transformCreateMode.ts
@@ -5,9 +5,8 @@ import { CE_GENERATION_STYLE } from '#/configs/const-enum/CE_GENERATION_STYLE';
 import type { TBundleOptions } from '#/configs/interfaces/TBundleOptions';
 import type { TCommandBuildArgvOptions } from '#/configs/interfaces/TCommandBuildArgvOptions';
 import type { TCreateOptions } from '#/configs/interfaces/TCreateOptions';
-import { posixResolve } from '#/modules/path/modules/posixResolve';
 import { getDirname } from 'my-node-fp';
-import path from 'node:path';
+import pathe from 'pathe';
 import type { SetRequired } from 'type-fest';
 
 export async function transformCreateMode(
@@ -20,8 +19,8 @@ export async function transformCreateMode(
   },
 ): Promise<TCreateOptions> {
   const startFrom =
-    argv.startFrom ?? option.startFrom ?? posixResolve(await getDirname(argv.project));
-  const resolvedStartFrom = path.isAbsolute(startFrom) ? startFrom : posixResolve(startFrom);
+    argv.startFrom ?? option.startFrom ?? pathe.resolve(await getDirname(argv.project));
+  const resolvedStartFrom = pathe.isAbsolute(startFrom) ? startFrom : pathe.resolve(startFrom);
 
   return {
     mode: CE_CTIX_BUILD_MODE.CREATE_MODE,

--- a/src/modules/values/__tests__/valid.type.test.ts
+++ b/src/modules/values/__tests__/valid.type.test.ts
@@ -1,4 +1,5 @@
 import { getCheckedValue } from '#/modules/values/getCheckedValue';
+import { isConfigComment } from '#/modules/values/isConfigComment';
 import { describe, expect, it } from 'vitest';
 
 describe('getValidValue', () => {
@@ -16,5 +17,30 @@ describe('getValidValue', () => {
     expect(r03).toEqual('hello');
     expect(r04).toBeUndefined();
     expect(r05).toBeUndefined();
+  });
+});
+
+describe('isConfigComment', () => {
+  it('configuration saved on package.json', () => {
+    const r01 = isConfigComment({
+      configComment: false,
+      configPosition: 'package.json',
+    });
+
+    expect(r01).toBeFalsy();
+  });
+
+  it('configuration saved on tsconfig or ctirc', () => {
+    const r01 = isConfigComment({
+      configComment: false,
+      configPosition: '.ctirc',
+    });
+    const r02 = isConfigComment({
+      configComment: true,
+      configPosition: 'tsconfig.json',
+    });
+
+    expect(r01).toBeFalsy();
+    expect(r02).toBeTruthy();
   });
 });

--- a/src/modules/values/isConfigComment.ts
+++ b/src/modules/values/isConfigComment.ts
@@ -1,0 +1,11 @@
+import type { IInitQuestionAnswer } from '#/cli/interfaces/IInitQuestionAnswer';
+
+export function isConfigComment(
+  answer: Pick<IInitQuestionAnswer, 'configComment' | 'configPosition'>,
+) {
+  if (answer.configPosition === 'package.json') {
+    return false;
+  }
+
+  return answer.configComment;
+}

--- a/src/templates/templates/nestedOptionDefaultTemplate.ts
+++ b/src/templates/templates/nestedOptionDefaultTemplate.ts
@@ -1,52 +1,85 @@
 export const nestedOptionDefaultTemplate = `
 {
+  <%- if (it.isComment && it.options.mode != null) { -%>
   // build mode
   // - create: create an \`index.ts\` file in each directory
-  // - bundle: bundle all export information in one \`index.ts\` file 
-  "mode": "<%= it.mode %>",
+  // - bundle: bundle all export information in one \`index.ts\` file
+  <%- } -%>
+  <%- if (it.options.mode != null) { -%>
+  "mode": "<%= it.options.mode %>",
+  <%- } -%>
   
+  <%- if (it.isComment && it.options.project != null) { -%>
   // tsconfig.json path: you must pass path with filename, like this "./tsconfig.json"
   // only work root directory or cli parameter
   // 
   // @mode all
-  "project": "<%= it.project %>",
+  <%- } -%>
+  <%- if (it.options.project != null) { -%>
+  "project": "<%= it.options.project %>",
+  <%- } -%>
   
+  <%- if (it.isComment && it.options.exportFilename != null) { -%>
   // Export filename, if you not pass this field that use "index.ts" or "index.d.ts"
   // 
   // @mode create, bundle, remove
   // @default index.ts
-  "exportFilename": "<%= it.exportFilename %>",
+  <%- } -%>
+  <%- if (it.options.exportFilename != null) { -%>
+  "exportFilename": "<%= it.options.exportFilename %>",
+  <%- } -%>
   
+  <%- if (it.addEveryOptions && it.isComment && it.options.useSemicolon != null) { -%>
   // add ctix comment at first line of creted index.ts file, that remark created from ctix
   //
   // @mode create, bundle
   // @default false
-  "useSemicolon": <%= it.useSemicolon %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.useSemicolon != null) { -%>
+  "useSemicolon": <%= it.options.useSemicolon %>,
+  <%- } -%>
   
+  <%- if (it.addEveryOptions && it.isComment && it.options.useBanner != null) { -%>
   // add ctix comment at first line of creted index.ts file, that remark created from ctix
   //
   // @mode create, bundle
   // @default false
-  "useBanner": <%= it.useBanner %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.useBanner != null) { -%>
+  "useBanner": <%= it.options.useBanner %>,
+  <%- } -%>
   
+  <%- if (it.addEveryOptions && it.isComment && it.options.useTimestamp != null) { -%>
   // If specified as true, adds the created date to the top of the \`index.ts\` file,
   // this option only works if the \`useBanner\` option is enabled
   //
   // @mode create, bundle
   // @default false
-  "useTimestamp": <%= it.useTimestamp %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.useTimestamp != null) { -%>
+  "useTimestamp": <%= it.options.useTimestamp %>,
+  <%- } -%>
   
+  <%- if (it.addEveryOptions && it.isComment && it.options.quote != null) { -%>
   // quote mark " or '
   // @mode create, bundle
   // 
   // @default '
-  "quote": "<%= it.quote %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.quote != null) { -%>
+  "quote": "<%= it.options.quote %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.directive != null) { -%>
   // Use to add a literal like \`"use strict"\` to the top. It will be added before the banner.
   //
   // @mode create, bundle
-  "directive": "<%= it.directive %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.directive != null) { -%>
+  "directive": "<%= it.options.directive %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.fileExt != null) { -%>
   // keep file extension in export statement path
   //
   // if this option set true that see below
@@ -54,62 +87,105 @@ export const nestedOptionDefaultTemplate = `
   //
   // @mode create, bundle
   // @default none
-  "fileExt": "<%= it.fileExt %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.fileExt != null) { -%>
+  "fileExt": "<%= it.options.fileExt %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.overwrite != null) { -%>
   // overwrite each index.ts file
   // @mode create, bundle
   // @default false
-  "overwrite": <%= it.overwrite %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.overwrite != null) { -%>
+  "overwrite": <%= it.options.overwrite %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.backup != null) { -%>
   // Create a backup file if the \`index.ts\` file already exists. 
   // This option only works if the \`overwrite\` option is enabled.
   //
   // @mode create, bundle
   // @defulat true
-  "backup": <%= it.backup %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.backup != null) { -%>
+  "backup": <%= it.options.backup %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.generationStyle != null) { -%>
   // When generating the \`index.ts\` file, decide how you want to generate it
   //
   // @mode create, bundle
   // @default auto
-  "generationStyle": "<%= it.generationStyle %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.generationStyle != null) { -%>
+  "generationStyle": "<%= it.options.generationStyle %>",
+  <%- } -%>
 
+  <%- if (it.isComment && it.options.include != null) { -%>
   // A list of files to use when generating the index.ts file. If no value is set,
   // the value of the include setting set in the tsconfig.json file will be used
   //
   // @mode create, bundle
-  "include": <%= it.include %>,
+  <%- } -%>
+  <%- if (it.options.include != null) { -%>
+  "include": <%= it.options.include %>,
+  <%- } -%>
 
+  <%- if (it.isComment && it.options.exclude != null) { -%>
   // A list of files to exclude when generating the index.ts file. If no value is set,
   // the value of the exclude setting set in the tsconfig.json file is used
   //
   // @mode create, bundle
-  "exclude": <%= it.exclude %>,
+  <%- } -%>
+  <%- if (it.options.exclude != null) { -%>
+  "exclude": <%= it.options.exclude %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.skipEmptyDir != null) { -%>
   // If \`skipEmptyDir\` is set to true, an empty directory with no files will not create an \`index.ts\` file
   //
   // @mode create
-  // @default true 
-  "skipEmptyDir": <%= it.skipEmptyDir %>,
+  // @default true
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.skipEmptyDir != null) { -%>
+  "skipEmptyDir": <%= it.options.skipEmptyDir %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.startFrom != null) { -%>
   // Specify the starting directory to start creating the \`index.ts\` file
   //
   // @mode create
   // @default tsconfig.json file directory
-  "startFrom": "<%= it.startFrom %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.startFrom != null) { -%>
+  "startFrom": <%= it.options.startFrom %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.output != null) { -%>
   // Output directory. Default value is same project directory
   // @mode bundle
-  "output": "<%= it.output %>",
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.output != null) { -%>
+  "output": "<%= it.options.output %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.removeBackup != null) { -%>
   // remove with backup file
   // @mode remove
   // @default false
-  "removeBackup": <%= it.removeBackup %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.removeBackup != null) { -%>
+  "removeBackup": <%= it.options.removeBackup %>,
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.options.forceYes != null) { -%>
   // answer \`yes\` to all questions
   // @mode remove
   // @default false
-  "forceYes": <%= it.forceYes %>,
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.options.forceYes != null) { -%>
+  "forceYes": <%= it.options.forceYes %>,
+  <%- } -%>
 }
 `;

--- a/src/templates/templates/optionDefaultTemplate.ts
+++ b/src/templates/templates/optionDefaultTemplate.ts
@@ -1,23 +1,35 @@
 export const optionDefaultTemplate = `
 {
+  <%- if (it.addEveryOptions && it.isComment && it.spinnerStream != null) { -%>
   // Stream of cli spinner, you can pass stdout or stderr
   //
   // @mode all
   // @default stdout
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.spinnerStream != null) { -%>
   "spinnerStream": "<%= it.spinnerStream %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.progressStream) { -%>
   // Stream of cli progress, you can pass stdout or stderr
   //
   // @mode all
   // @default stdout
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.progressStream != null) { -%>
   "progressStream": "<%= it.progressStream %>",
+  <%- } -%>
 
+  <%- if (it.addEveryOptions && it.isComment && it.reasonerStream != null) { -%>
   // Stream of cli reasoner. Reasoner show name conflict error and already exist index.ts file error.
   // You can pass stdout or stderr
   //
   // @mode all
   // @default stderr
+  <%- } -%>
+  <%- if (it.addEveryOptions && it.reasonerStream != null) { -%>
   "reasonerStream": "<%= it.reasonerStream %>",
+  <%- } -%>
 
   "options": [<%= it.options %>]
 }


### PR DESCRIPTION
- add additional questions to the configuration file creation process:
  - include descriptive comments in the configuration file or not?
  - add only required options or all options?
  - create a backup of the `tsconfig.json` or `package.json` file or not?
- add a new json package to preserve comments:
  - add the comment-json package