### PR TITLE
fix: create mode - fix skipEmptyDir options not working #167

### DIFF
--- a/examples/type13/.ctirc
+++ b/examples/type13/.ctirc
@@ -1,0 +1,26 @@
+{
+  "spinnerStream": "stdout",
+  "progressStream": "stdout",
+  "reasonerStream": "stderr",
+  "options": [
+    {
+      "mode": "create",
+      "project": "examples/type13/tsconfig.json",
+      "exportFilename": "index.ts",
+      "useSemicolon": true,
+      "useBanner": false,
+      "useTimestamp": false,
+      "quote": "'",
+      "directive": "",
+      "fileExt": "none",
+      "overwrite": true,
+      "backup": false,
+      "generationStyle": "auto",
+      "include": ["**/*.ts"],
+      "exclude": [],
+      "skipEmptyDir": true,
+      "removeBackup": false,
+      "forceYes": false
+    }
+  ]
+}

--- a/examples/type13/src/BubbleCls.tsx
+++ b/examples/type13/src/BubbleCls.tsx
@@ -1,0 +1,5 @@
+/** @ctix-exclude  */
+
+export class BubbleCls {
+  public name: string = 'BubbleCls';
+}

--- a/examples/type13/src/ComparisonCls.tsx
+++ b/examples/type13/src/ComparisonCls.tsx
@@ -1,0 +1,3 @@
+export class ComparisonCls {
+  private name: string = 'ComparisonCls';
+}

--- a/examples/type13/src/HandsomelyCls.tsx
+++ b/examples/type13/src/HandsomelyCls.tsx
@@ -1,0 +1,3 @@
+export class HandsomelyCls {
+  public name: string = 'HandsomelyCls';
+}

--- a/examples/type13/src/SampleCls.tsx
+++ b/examples/type13/src/SampleCls.tsx
@@ -1,0 +1,3 @@
+export class SampleCls {
+  public name: string = 'SampleCls';
+}

--- a/examples/type13/src/createTypeScriptIndex.d.ts
+++ b/examples/type13/src/createTypeScriptIndex.d.ts
@@ -1,0 +1,20 @@
+import fastGlob from 'fast-glob';
+
+export interface ICreateTsIndexOption {
+  fileFirst?: boolean;
+  addNewline?: boolean;
+  useSemicolon?: boolean;
+  useTimestamp?: boolean;
+  includeCWD?: boolean;
+  excludes?: string[];
+  fileExcludePatterns?: string[];
+  targetExts?: string[];
+  globOptions?: fastGlob.IOptions;
+}
+export declare function indexWriter(
+  directory: string,
+  directories: string[],
+  option: ICreateTsIndexOption,
+): Promise<void>;
+
+export declare function createTypeScriptIndex(_option: ICreateTsIndexOption): Promise<void>;

--- a/examples/type13/src/ctix.d.ts
+++ b/examples/type13/src/ctix.d.ts
@@ -1,0 +1,1 @@
+export * from './createTypeScriptIndex';

--- a/examples/type13/src/juvenile/TriteCls.ts
+++ b/examples/type13/src/juvenile/TriteCls.ts
@@ -1,0 +1,3 @@
+export class TriteCls {
+  name: string = 'TriteCls';
+}

--- a/examples/type13/src/juvenile/apple/ChildlikeCls.ts
+++ b/examples/type13/src/juvenile/apple/ChildlikeCls.ts
@@ -1,0 +1,3 @@
+export class ChildlikeCls {
+  name: string = 'ChildlikeCls';
+}

--- a/examples/type13/src/juvenile/apple/FlakyCls.ts
+++ b/examples/type13/src/juvenile/apple/FlakyCls.ts
@@ -1,0 +1,3 @@
+export class FlakyCls {
+  name: string = 'FlakyCls';
+}

--- a/examples/type13/src/juvenile/apple/WhisperingCls.ts
+++ b/examples/type13/src/juvenile/apple/WhisperingCls.ts
@@ -1,0 +1,3 @@
+export class WhisperingCls {
+  name: string = 'WhisperingCls';
+}

--- a/examples/type13/src/juvenile/spill/ExperienceCls.ts
+++ b/examples/type13/src/juvenile/spill/ExperienceCls.ts
@@ -1,0 +1,3 @@
+export class ExperienceCls {
+  name: string = 'ExperienceCls';
+}

--- a/examples/type13/src/popcorn/finance/discipline/case02.ts
+++ b/examples/type13/src/popcorn/finance/discipline/case02.ts
@@ -1,0 +1,4 @@
+/* anonymous function ArrowDeclaration */
+export default () => {
+  return 'hello';
+};

--- a/examples/type13/src/popcorn/finance/discipline/case03.ts
+++ b/examples/type13/src/popcorn/finance/discipline/case03.ts
@@ -1,0 +1,4 @@
+/* named function FunctionDeclaration */
+export default function Case03() {
+  return 'hello';
+}

--- a/examples/type13/src/popcorn/lawyer/appliance/IKittens.ts
+++ b/examples/type13/src/popcorn/lawyer/appliance/IKittens.ts
@@ -1,0 +1,4 @@
+export default interface IKittens {
+  name: string;
+  age: number;
+}

--- a/examples/type13/src/popcorn/lawyer/appliance/TomatoesCls.ts
+++ b/examples/type13/src/popcorn/lawyer/appliance/TomatoesCls.ts
@@ -1,0 +1,3 @@
+export class TomatoesCls {
+  name: string = 'TomatoesCls';
+}

--- a/examples/type13/src/popcorn/lawyer/appliance/bomb.ts
+++ b/examples/type13/src/popcorn/lawyer/appliance/bomb.ts
@@ -1,0 +1,12 @@
+export const bomb = 'hello bombs!';
+
+export default () => {
+  return `
+  // popcorn;
+  // lawyer;
+  // appliance;
+  // kittens;
+  // bomb;
+  // tomatoes;
+  `;
+};

--- a/examples/type13/src/wellmade/carpenter/DiscussionCls.ts
+++ b/examples/type13/src/wellmade/carpenter/DiscussionCls.ts
@@ -1,0 +1,3 @@
+export class DiscussionCls {
+  name: string = 'DiscussionCls';
+}

--- a/examples/type13/src/wellmade/carpenter/MakeshiftCls.ts
+++ b/examples/type13/src/wellmade/carpenter/MakeshiftCls.ts
@@ -1,0 +1,3 @@
+export class MakeshiftCls {
+  name: string = 'MakeshiftCls';
+}

--- a/examples/type13/tsconfig.json
+++ b/examples/type13/tsconfig.json
@@ -1,0 +1,84 @@
+{
+  // This is an alias to @tsconfig/node12: https://github.com/tsconfig/bases
+  "extends": "@tsconfig/node18/tsconfig.json",
+
+  // Most ts-node options can be specified here using their programmatic names.
+  "ts-node": {
+    // It is faster to skip typechecking.
+    // Remove if you want ts-node to do typechecking.
+    "transpileOnly": true,
+
+    "files": true,
+
+    "compilerOptions": {
+      // compilerOptions specified here will override those declared below,
+      // but *only* in ts-node.  Useful if you want ts-node and tsc to use
+      // different options with a single tsconfig.json.
+    }
+  },
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    /* Basic Options */
+    // "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    // "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [ "dom", "ES2017", "ES2018", "ES2019", ],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true /* Generates corresponding '.map' file. */,
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    "removeComments": true /* Do not emit comments to output. */,
+    // "noEmit": true,                        /* Do not emit outputs. */
+    "importHelpers": true /* Import emit helpers from 'tslib'. */,
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": false,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+
+    /* Module Resolution Options */
+    "module": "CommonJS",
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "." /* Base directory to resolve non-absolute module names. */,
+    "paths": {} /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./maps",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
+    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
+
+    "pretty": true,
+    "typeRoots": []
+  },
+  "exclude": ["../src/**/*"]
+}

--- a/src/cli/builders/setModeCreateOptions.ts
+++ b/src/cli/builders/setModeCreateOptions.ts
@@ -7,7 +7,6 @@ export function setModeCreateOptions<T = Argv<IModeCreateOptions>>(args: Argv<IM
       describe:
         'if `skipEmptyDir` is set to true, an empty directory with no files will not create an `index.ts` file',
       type: 'boolean',
-      default: true,
     })
     .option('start-from', {
       describe: 'specify the starting directory to start creating the `index.ts` file',

--- a/src/configs/transforms/transformCreateMode.ts
+++ b/src/configs/transforms/transformCreateMode.ts
@@ -35,7 +35,8 @@ export async function transformCreateMode(
     fileExt: argv.fileExt ?? option.fileExt ?? CE_EXTENSION_PROCESSING.NOT_EXTENSION,
     overwrite: argv.overwrite ?? option.overwrite ?? false,
     backup: argv.backup ?? option.backup ?? true,
-    generationStyle: argv.generationStyle ?? option.generationStyle ?? CE_GENERATION_STYLE.AUTO,
+    generationStyle:
+      argv.generationStyle ?? option.generationStyle ?? CE_GENERATION_STYLE.DEFAULT_STAR_NAMED_STAR,
     include: option.include,
     exclude: option.exclude,
 

--- a/src/modules/file/__tests__/get.create.mode.file.tree.test.ts
+++ b/src/modules/file/__tests__/get.create.mode.file.tree.test.ts
@@ -1,0 +1,240 @@
+import { getCreateModeFileTree } from '#/modules/file/getCreateModeFileTree';
+import pathe from 'pathe';
+import { describe, expect, it } from 'vitest';
+
+// get.create.mode.file.tree
+describe('getCreateModeFiles', () => {
+  const type04Dir = pathe.join(process.cwd(), 'examples', 'type04');
+
+  it('start from process.cwd()', async () => {
+    const files = await getCreateModeFileTree(type04Dir);
+    const expectFiles = {
+      root: {
+        kind: 'root',
+        name: 'type04',
+        path: type04Dir,
+        children: [
+          {
+            kind: 'child',
+            name: 'juvenile',
+            path: pathe.join(type04Dir, 'juvenile'),
+            parent: type04Dir,
+            children: [
+              {
+                kind: 'child',
+                name: 'apple',
+                path: pathe.join(type04Dir, 'juvenile/apple'),
+                parent: pathe.join(type04Dir, 'juvenile'),
+                children: [],
+              },
+              {
+                kind: 'child',
+                name: 'spill',
+                path: pathe.join(type04Dir, 'juvenile/spill'),
+                parent: pathe.join(type04Dir, 'juvenile'),
+                children: [],
+              },
+            ],
+          },
+          {
+            kind: 'child',
+            name: 'popcorn',
+            path: pathe.join(type04Dir, 'popcorn'),
+            parent: type04Dir,
+            children: [
+              {
+                kind: 'child',
+                name: 'finance',
+                path: pathe.join(type04Dir, 'popcorn/finance'),
+                parent: pathe.join(type04Dir, 'popcorn'),
+                children: [
+                  {
+                    kind: 'child',
+                    name: 'discipline',
+                    path: pathe.join(type04Dir, 'popcorn/finance/discipline'),
+                    parent: pathe.join(type04Dir, 'popcorn/finance'),
+                    children: [],
+                  },
+                ],
+              },
+              {
+                kind: 'child',
+                name: 'lawyer',
+                path: pathe.join(type04Dir, 'popcorn/lawyer'),
+                parent: pathe.join(type04Dir, 'popcorn'),
+                children: [
+                  {
+                    kind: 'child',
+                    name: 'appliance',
+                    path: pathe.join(type04Dir, 'popcorn/lawyer/appliance'),
+                    parent: pathe.join(type04Dir, 'popcorn/lawyer'),
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            kind: 'child',
+            name: 'wellmade',
+            path: pathe.join(type04Dir, 'wellmade'),
+            parent: type04Dir,
+            children: [
+              {
+                kind: 'child',
+                name: 'carpenter',
+                path: pathe.join(type04Dir, 'wellmade/carpenter'),
+                parent: pathe.join(type04Dir, 'wellmade'),
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      children: [
+        {
+          kind: 'child',
+          name: 'juvenile',
+          path: pathe.join(type04Dir, 'juvenile'),
+          parent: type04Dir,
+          children: [
+            {
+              kind: 'child',
+              name: 'apple',
+              path: pathe.join(type04Dir, 'juvenile/apple'),
+              parent: pathe.join(type04Dir, 'juvenile'),
+              children: [],
+            },
+            {
+              kind: 'child',
+              name: 'spill',
+              path: pathe.join(type04Dir, 'juvenile/spill'),
+              parent: pathe.join(type04Dir, 'juvenile'),
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: 'child',
+          name: 'popcorn',
+          path: pathe.join(type04Dir, 'popcorn'),
+          parent: type04Dir,
+          children: [
+            {
+              kind: 'child',
+              name: 'finance',
+              path: pathe.join(type04Dir, 'popcorn/finance'),
+              parent: pathe.join(type04Dir, 'popcorn'),
+              children: [
+                {
+                  kind: 'child',
+                  name: 'discipline',
+                  path: pathe.join(type04Dir, 'popcorn/finance/discipline'),
+                  parent: pathe.join(type04Dir, 'popcorn/finance'),
+                  children: [],
+                },
+              ],
+            },
+            {
+              kind: 'child',
+              name: 'lawyer',
+              path: pathe.join(type04Dir, 'popcorn/lawyer'),
+              parent: pathe.join(type04Dir, 'popcorn'),
+              children: [
+                {
+                  kind: 'child',
+                  name: 'appliance',
+                  path: pathe.join(type04Dir, 'popcorn/lawyer/appliance'),
+                  parent: pathe.join(type04Dir, 'popcorn/lawyer'),
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          kind: 'child',
+          name: 'wellmade',
+          path: pathe.join(type04Dir, 'wellmade'),
+          parent: type04Dir,
+          children: [
+            {
+              kind: 'child',
+              name: 'carpenter',
+              path: pathe.join(type04Dir, 'wellmade/carpenter'),
+              parent: pathe.join(type04Dir, 'wellmade'),
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: 'child',
+          name: 'carpenter',
+          path: pathe.join(type04Dir, 'wellmade/carpenter'),
+          parent: pathe.join(type04Dir, 'wellmade'),
+          children: [],
+        },
+        {
+          kind: 'child',
+          name: 'finance',
+          path: pathe.join(type04Dir, 'popcorn/finance'),
+          parent: pathe.join(type04Dir, 'popcorn'),
+          children: [
+            {
+              kind: 'child',
+              name: 'discipline',
+              path: pathe.join(type04Dir, 'popcorn/finance/discipline'),
+              parent: pathe.join(type04Dir, 'popcorn/finance'),
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: 'child',
+          name: 'lawyer',
+          path: pathe.join(type04Dir, 'popcorn/lawyer'),
+          parent: pathe.join(type04Dir, 'popcorn'),
+          children: [
+            {
+              kind: 'child',
+              name: 'appliance',
+              path: pathe.join(type04Dir, 'popcorn/lawyer/appliance'),
+              parent: pathe.join(type04Dir, 'popcorn/lawyer'),
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: 'child',
+          name: 'appliance',
+          path: pathe.join(type04Dir, 'popcorn/lawyer/appliance'),
+          parent: pathe.join(type04Dir, 'popcorn/lawyer'),
+          children: [],
+        },
+        {
+          kind: 'child',
+          name: 'discipline',
+          path: pathe.join(type04Dir, 'popcorn/finance/discipline'),
+          parent: pathe.join(type04Dir, 'popcorn/finance'),
+          children: [],
+        },
+        {
+          kind: 'child',
+          name: 'apple',
+          path: pathe.join(type04Dir, 'juvenile/apple'),
+          parent: pathe.join(type04Dir, 'juvenile'),
+          children: [],
+        },
+        {
+          kind: 'child',
+          name: 'spill',
+          path: pathe.join(type04Dir, 'juvenile/spill'),
+          parent: pathe.join(type04Dir, 'juvenile'),
+          children: [],
+        },
+      ],
+    };
+
+    expect(files).toMatchObject(expectFiles);
+  });
+});

--- a/src/modules/file/__tests__/get.export.statement.from.map.test.ts
+++ b/src/modules/file/__tests__/get.export.statement.from.map.test.ts
@@ -1,0 +1,65 @@
+import type { IExportStatement } from '#/compilers/interfaces/IExportStatement';
+import { getExportStatementFromMap } from '#/modules/file/getExportStatementFromMap';
+import { filenamify } from '#/modules/path/filenamify';
+import { replaceSepToPosix } from 'my-node-fp';
+import { describe, expect, it } from 'vitest';
+
+describe('getExportStatementFromMap', () => {
+  const filename01 = 'hello.ts';
+  const filename02 = 'world.ts';
+  const statement01: IExportStatement[] = [
+    {
+      path: {
+        filename: filename01,
+        dirPath: replaceSepToPosix(process.cwd()),
+        relativePath: '..',
+      },
+      depth: 2,
+      pos: {
+        line: 1,
+        column: 1,
+      },
+      identifier: { name: 'Hero', alias: filenamify(filename01) },
+      isAnonymous: false,
+      isPureType: false,
+      isDefault: false,
+      isExcluded: false,
+      comments: [],
+    },
+  ];
+  const statement02: IExportStatement[] = [
+    {
+      path: {
+        filename: filename02,
+        dirPath: replaceSepToPosix(process.cwd()),
+        relativePath: '..',
+      },
+      depth: 2,
+      pos: {
+        line: 9,
+        column: 1,
+      },
+      identifier: { name: 'Ability', alias: filenamify(filename02) },
+      isAnonymous: false,
+      isPureType: false,
+      isDefault: false,
+      isExcluded: false,
+      comments: [],
+    },
+  ];
+
+  const map = new Map<string, IExportStatement[]>([
+    [filename01, statement01],
+    [filename02, statement02],
+  ]);
+
+  it('find from the map', () => {
+    const result = getExportStatementFromMap(filename01, map);
+    expect(result).toEqual(statement01);
+  });
+
+  it('cannot find from the map', () => {
+    const result = getExportStatementFromMap('cannot-found-this-name', map);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/modules/file/__tests__/glob.files.test.ts
+++ b/src/modules/file/__tests__/glob.files.test.ts
@@ -11,6 +11,7 @@ describe('getGlobFiles', () => {
 
     expect(files).toEqual([
       'tsconfig.json',
+      'examples/type13/tsconfig.json',
       'examples/type12/tsconfig.json',
       'examples/type11/tsconfig.json',
       'examples/type10/tsconfig.json',
@@ -36,6 +37,7 @@ describe('getGlobFiles', () => {
 
     expect(files).toEqual([
       posixJoin(process.cwd(), 'tsconfig.json'),
+      posixJoin(process.cwd(), 'examples/type13/tsconfig.json'),
       posixJoin(process.cwd(), 'examples/type12/tsconfig.json'),
       posixJoin(process.cwd(), 'examples/type11/tsconfig.json'),
       posixJoin(process.cwd(), 'examples/type10/tsconfig.json'),

--- a/src/modules/file/getCreateModeFileTree.ts
+++ b/src/modules/file/getCreateModeFileTree.ts
@@ -1,0 +1,55 @@
+import type { IModuleChild } from '#/modules/file/interfaces/IModuleChild';
+import type { IModuleRoot } from '#/modules/file/interfaces/IModuleRoot';
+import { getParentDir } from '#/modules/path/getParentDir';
+import fs from 'fs';
+import { orThrow } from 'my-easy-fp';
+import pathe from 'pathe';
+
+export async function getCreateModeFileTree(startFrom: string) {
+  const resolved = pathe.resolve(startFrom);
+  const fileOrDirs = await fs.promises.readdir(resolved, { withFileTypes: true, recursive: true });
+  const dirs = fileOrDirs.filter((fileOrDir) => fileOrDir.isDirectory());
+
+  // root 노드를 만든다
+  const root: IModuleRoot = {
+    kind: 'root',
+    name: pathe.basename(resolved),
+    path: resolved,
+    children: [],
+  };
+
+  const children = dirs
+    .map((dir) => {
+      const path = pathe.resolve(pathe.join(dir.path, dir.name));
+      const parent = orThrow(getParentDir(path));
+
+      const child: IModuleChild = {
+        kind: 'child',
+        name: dir.name,
+        path,
+        parent,
+        children: [],
+        statements: [],
+        isSkip: false,
+      };
+
+      return child;
+    })
+    .filter((child) => child.path !== resolved);
+
+  const map = new Map(children.map((child) => [child.path, child]));
+
+  children.forEach((child) => {
+    const parent = map.get(child.parent);
+
+    if (parent != null) {
+      // root 아닌 부모 노드를 가지고 있는 경우
+      parent.children.push(child);
+    } else if (parent == null && child.parent === root.path) {
+      // root 노드 자식인 경우
+      root.children.push(child);
+    }
+  });
+
+  return { root, children };
+}

--- a/src/modules/file/getExportStatementFromMap.ts
+++ b/src/modules/file/getExportStatementFromMap.ts
@@ -1,0 +1,9 @@
+import type { IExportStatement } from '#/compilers/interfaces/IExportStatement';
+
+export function getExportStatementFromMap(
+  key: string,
+  map: Map<string, IExportStatement[]>,
+): IExportStatement[] {
+  const result = map.get(key) ?? [];
+  return result;
+}

--- a/src/modules/file/interfaces/IModuleChild.ts
+++ b/src/modules/file/interfaces/IModuleChild.ts
@@ -1,0 +1,11 @@
+import type { IExportStatement } from '#/compilers/interfaces/IExportStatement';
+
+export interface IModuleChild {
+  kind: 'child';
+  name: string;
+  path: string;
+  parent: string;
+  isSkip: boolean;
+  children: IModuleChild[];
+  statements: IExportStatement[];
+}

--- a/src/modules/file/interfaces/IModuleRoot.ts
+++ b/src/modules/file/interfaces/IModuleRoot.ts
@@ -1,0 +1,8 @@
+import type { IModuleChild } from '#/modules/file/interfaces/IModuleChild';
+
+export interface IModuleRoot {
+  kind: 'root';
+  name: string;
+  path: string;
+  children: IModuleChild[];
+}

--- a/src/modules/file/processSkipEmptyDirOnFileTree.ts
+++ b/src/modules/file/processSkipEmptyDirOnFileTree.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-param-reassign */
+
+import type { IExportStatement } from '#/compilers/interfaces/IExportStatement';
+import type { getCreateModeFileTree } from '#/modules/file/getCreateModeFileTree';
+import { getExportStatementFromMap } from '#/modules/file/getExportStatementFromMap';
+import { isFalse, orThrow } from 'my-easy-fp';
+import type { AsyncReturnType } from 'type-fest';
+
+export function processSkipEmptyDirOnFileTree(params: {
+  tree: AsyncReturnType<typeof getCreateModeFileTree>;
+  dirPathMap: Map<string, IExportStatement[]>;
+  skipEmptyDir: boolean;
+}): { path: string; children: string[] }[] {
+  if (isFalse(params.skipEmptyDir)) {
+    const dirPaths = params.tree.children.map((child) => {
+      return { path: child.path, children: child.children.map((grandchild) => grandchild.path) };
+    });
+
+    return dirPaths;
+  }
+
+  const map = new Map(params.tree.children.map((child) => [child.path, child]));
+
+  params.tree.children.forEach((child) => {
+    const statements = getExportStatementFromMap(child.path, params.dirPathMap);
+
+    child.statements.push(...statements);
+    child.isSkip = statements.length <= 0;
+
+    if (child.isSkip) {
+      const parent =
+        child.parent === params.tree.root.path ? params.tree.root : orThrow(map.get(child.parent));
+
+      child.children = child.children.map((grandchild) => {
+        grandchild.parent = parent.path;
+        return grandchild;
+      });
+
+      parent.children = [
+        ...parent.children.filter((parentchild) => parentchild.path !== child.path),
+        ...child.children,
+      ];
+    }
+  });
+
+  const dirPaths = params.tree.children
+    .filter((child) => !child.isSkip)
+    .map((child) => {
+      return {
+        path: child.path,
+        children: child.children.map((grandchild) => grandchild.path),
+      };
+    });
+
+  return dirPaths;
+}


### PR DESCRIPTION
- Fixed an issue where the skipEmptyDir option was not working in create mode.
- Fixed an issue where the generationStyle option was not applied in create mode.