### PR TITLE
docs(readme): add TypeScript version requirement under Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ A [barrel](https://basarat.gitbook.io/typescript/main-1/barrel) is a way to roll
 npm install ctix --save-dev
 ```
 
+> **TypeScript version requirement**
+>
+> ctix 2.8.0 requires **TypeScript >=5.0.0 and <6.0.0**.
+>
+> TypeScript 6.x shifts to ESM-first defaults and introduces breaking changes to `moduleResolution` and `baseUrl` that are not yet supported by ctix. Until ctix adds ESM support, please keep your TypeScript version in the 5.x range.
+>
+> ```bash
+> # install a compatible TypeScript version explicitly
+> npm install typescript@">=5 <6" --save-dev
+> ```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a callout block under the Installation section explaining that ctix 2.8.0 requires TypeScript >=5.0.0 <6.0.0
- TypeScript 6.x introduces ESM-first defaults with breaking changes to `moduleResolution` and `baseUrl` not yet supported by ctix
- Include an explicit install command so users can pin a compatible TypeScript version

## Test plan

- [ ] Verify the callout renders correctly on GitHub and npm README
- [ ] Confirm the TypeScript version range matches `peerDependencies` in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)